### PR TITLE
Throttling frame rate for consistent ball animation

### DIFF
--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -268,21 +268,32 @@ export function petPanelApp(
     }
 
     /// Bouncing ball components, credit https://stackoverflow.com/a/29982343
-    const gravity: number = 0.2,
+    const gravity: number = 0.6,
         damping: number = 0.9,
-        traction: number = 0.8;
+        traction: number = 0.8,
+        interval: number = 1000 / 24; // msec for single frame
+    let then: number = 0; // last draw
     var ballState: BallState;
 
     function resetBall() {
         canvas.style.display = 'block';
-        ballState = new BallState(100, 100, 2, 5);
+        ballState = new BallState(100, 100, 4, 5);
     }
 
     function throwBall() {
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
         if (!ballState.paused) {
             requestAnimationFrame(throwBall);
         }
+
+        // throttling the frame rate
+        const now = Date.now();
+        const elapsed = now - then;
+        if (elapsed <= interval) {
+            return;
+        }
+        then = now - (elapsed % interval);
+
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
 
         if (ballState.cx + ballRadius >= canvas.width) {
             ballState.vx = -ballState.vx * damping;


### PR DESCRIPTION
This is a fix for the ball speed issues (#94 and #119).

* Adding a frame rate throttle (max 24 fps)
* Also adjusted the initial velocities and gravity to make it work naturally with the frame rate.


https://user-images.githubusercontent.com/81522/193386136-5242f48b-7c51-4726-93a9-3fb6870f8624.mov

The frame rate no longer goes up after throwing ball multiple times.

Thank you for the great extension!