### PR TITLE
Add the ability to set a custom name for a pet

### DIFF
--- a/media/main-bundle.js
+++ b/media/main-bundle.js
@@ -10,7 +10,7 @@
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.COCKATIEL_NAMES = exports.ROCKY_NAMES = exports.ZAPPY_NAMES = exports.DUCK_NAMES = exports.SNAKE_NAMES = exports.TOTORO_NAMES = exports.CLIPPY_NAMES = exports.CRAB_NAMES = exports.DOG_NAMES = exports.CAT_NAMES = void 0;
+exports.randomName = exports.COCKATIEL_NAMES = exports.ROCKY_NAMES = exports.ZAPPY_NAMES = exports.DUCK_NAMES = exports.SNAKE_NAMES = exports.TOTORO_NAMES = exports.CLIPPY_NAMES = exports.CRAB_NAMES = exports.DOG_NAMES = exports.CAT_NAMES = void 0;
 exports.CAT_NAMES = new Map([
     [1, 'Bella'],
     [2, 'Charlie'],
@@ -327,6 +327,47 @@ exports.COCKATIEL_NAMES = new Map([
     [13, 'Dame Judi Finch'],
     [14, 'Kanye Nest'],
 ]);
+function randomName(type) {
+    var collection;
+    switch (type) {
+        case "cat" /* PetType.cat */:
+            collection = exports.CAT_NAMES;
+            break;
+        case "dog" /* PetType.dog */:
+            collection = exports.DOG_NAMES;
+            break;
+        case "crab" /* PetType.crab */:
+            collection = exports.CRAB_NAMES;
+            break;
+        case "clippy" /* PetType.clippy */:
+            collection = exports.CLIPPY_NAMES;
+            break;
+        case "totoro" /* PetType.totoro */:
+            collection = exports.TOTORO_NAMES;
+            break;
+        case "snake" /* PetType.snake */:
+            collection = exports.SNAKE_NAMES;
+            break;
+        case "rubber-duck" /* PetType.rubberduck */:
+            collection = exports.DUCK_NAMES;
+            break;
+        case "zappy" /* PetType.zappy */:
+            collection = exports.ZAPPY_NAMES;
+            break;
+        case "rocky" /* PetType.rocky */:
+            collection = exports.ROCKY_NAMES;
+            break;
+        case "cockatiel" /* PetType.cockatiel */:
+            collection = exports.COCKATIEL_NAMES;
+            break;
+        default:
+            collection = exports.CAT_NAMES;
+            break;
+    }
+    return (collection.get(Math.floor(Math.random() * collection.size) + 1) ??
+        'Unknown');
+}
+exports.randomName = randomName;
 
 
 /***/ }),
@@ -340,6 +381,8 @@ exports.COCKATIEL_NAMES = new Map([
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.petPanelApp = exports.saveState = exports.allPets = void 0;
+// This script will be run within the webview itself
+const names_1 = __webpack_require__(/*! ../common/names */ "./src/common/names.ts");
 const pets_1 = __webpack_require__(/*! ./pets */ "./src/panel/pets.ts");
 const states_1 = __webpack_require__(/*! ./states */ "./src/panel/states.ts");
 const vscode = window.acquireVsCodeApi();
@@ -417,7 +460,7 @@ function addPetToPanel(petType, basePetUri, petColor, petSize, left, bottom, flo
     collisionElement.className = 'collision';
     document.getElementById('petsContainer').appendChild(collisionElement);
     const root = basePetUri + '/' + petType + '/' + petColor;
-    console.log('Creating new pet : ', petType, root);
+    console.log('Creating new pet : ', petType, root, petColor, petSize, name);
     var newPet = (0, pets_1.createPet)(petType, petSpriteElement, collisionElement, petSize, left, bottom, root, floor, name);
     petCounter++;
     startAnimations(collisionElement, newPet);
@@ -456,7 +499,7 @@ function recoverState(basePetUri, petSize, floor) {
             p.petType = 'rubber-duck';
         }
         try {
-            var newPet = addPetToPanel(p.petType ?? "cat" /* PetType.cat */, basePetUri, p.petColor ?? "brown" /* PetColor.brown */, petSize, parseInt(p.elLeft ?? '0'), parseInt(p.elBottom ?? '0'), floor, p.petName);
+            var newPet = addPetToPanel(p.petType ?? "cat" /* PetType.cat */, basePetUri, p.petColor ?? "brown" /* PetColor.brown */, petSize, parseInt(p.elLeft ?? '0'), parseInt(p.elBottom ?? '0'), floor, p.petName ?? (0, names_1.randomName)(p.petType ?? "cat" /* PetType.cat */));
             exports.allPets.push(newPet);
             recoveryMap.set(newPet.pet, p);
         }
@@ -571,7 +614,7 @@ function petPanelApp(basePetUri, theme, themeKind, petColor, petSize, petType) {
     if (!state) {
         console.log('No state, starting a new session.');
         petCounter = 1;
-        exports.allPets.push(addPetToPanel(petType, basePetUri, petColor, petSize, randomStartPosition(), floor, floor, undefined));
+        exports.allPets.push(addPetToPanel(petType, basePetUri, petColor, petSize, randomStartPosition(), floor, floor, (0, names_1.randomName)(petType)));
         saveState();
     }
     else {
@@ -593,7 +636,7 @@ function petPanelApp(basePetUri, theme, themeKind, petColor, petSize, petType) {
                 });
                 break;
             case 'spawn-pet':
-                exports.allPets.push(addPetToPanel(message.type, basePetUri, message.color, petSize, randomStartPosition(), floor, floor, undefined));
+                exports.allPets.push(addPetToPanel(message.type, basePetUri, message.color, petSize, randomStartPosition(), floor, floor, message.name ?? (0, names_1.randomName)(message.type)));
                 saveState();
                 break;
             case 'list-pets':
@@ -662,7 +705,6 @@ window.addEventListener('resize', function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createPet = exports.InvalidPetException = exports.Rocky = exports.Zappy = exports.Crab = exports.Cockatiel = exports.RubberDuck = exports.Clippy = exports.Snake = exports.Dog = exports.Cat = exports.Totoro = exports.PetCollection = exports.PetElement = exports.InvalidStateException = void 0;
 const states_1 = __webpack_require__(/*! ./states */ "./src/panel/states.ts");
-const names_1 = __webpack_require__(/*! ../common/names */ "./src/common/names.ts");
 class InvalidStateException {
 }
 exports.InvalidStateException = InvalidStateException;
@@ -1487,75 +1529,44 @@ class Rocky extends BasePetType {
 }
 exports.Rocky = Rocky;
 class InvalidPetException {
+    message;
+    constructor(message) {
+        this.message = message;
+    }
 }
 exports.InvalidPetException = InvalidPetException;
-function getPetName(collection, label, count) {
-    if (collection.has(count)) {
-        return collection.get(count) ?? label + count;
-    }
-    else {
-        return label + count;
-    }
-}
 function createPet(petType, el, collision, size, left, bottom, petRoot, floor, name) {
+    if (name === undefined) {
+        throw new InvalidPetException('name is undefined');
+    }
     if (petType === 'totoro') {
-        if (name === undefined) {
-            name = getPetName(names_1.TOTORO_NAMES, "totoro" /* PetType.totoro */, Totoro.count + 1);
-        }
         return new Totoro(el, collision, size, left, bottom, petRoot, floor, name, 3 /* PetSpeed.normal */);
     }
     if (petType === 'cat') {
-        if (name === undefined) {
-            name = getPetName(names_1.CAT_NAMES, "cat" /* PetType.cat */, Cat.count + Dog.count + 1);
-        } // Cat and dog share the same name list
         return new Cat(el, collision, size, left, bottom, petRoot, floor, name, 3 /* PetSpeed.normal */);
     }
     else if (petType === 'dog') {
-        if (name === undefined) {
-            name = getPetName(names_1.DOG_NAMES, "dog" /* PetType.dog */, Dog.count + Cat.count + 1);
-        } // Cat and dog share the same name list
         return new Dog(el, collision, size, left, bottom, petRoot, floor, name, 3 /* PetSpeed.normal */);
     }
     else if (petType === 'snake') {
-        if (name === undefined) {
-            name = getPetName(names_1.SNAKE_NAMES, "snake" /* PetType.snake */, Snake.count + 1);
-        }
         return new Snake(el, collision, size, left, bottom, petRoot, floor, name, 1 /* PetSpeed.verySlow */);
     }
     else if (petType === 'clippy') {
-        if (name === undefined) {
-            name = getPetName(names_1.CLIPPY_NAMES, "clippy" /* PetType.clippy */, Clippy.count + 1);
-        }
         return new Clippy(el, collision, size, left, bottom, petRoot, floor, name, 2 /* PetSpeed.slow */);
     }
     else if (petType === 'cockatiel') {
-        if (name === undefined) {
-            name = getPetName(names_1.COCKATIEL_NAMES, "cockatiel" /* PetType.cockatiel */, Cockatiel.count + 1);
-        }
         return new Cockatiel(el, collision, size, left, bottom, petRoot, floor, name, 3 /* PetSpeed.normal */);
     }
     else if (petType === 'crab') {
-        if (name === undefined) {
-            name = getPetName(names_1.CRAB_NAMES, "crab" /* PetType.crab */, Crab.count + 1);
-        }
         return new Crab(el, collision, size, left, bottom, petRoot, floor, name, 2 /* PetSpeed.slow */);
     }
     else if (petType === 'rubber-duck') {
-        if (name === undefined) {
-            name = getPetName(names_1.DUCK_NAMES, "rubber-duck" /* PetType.rubberduck */, RubberDuck.count + 1);
-        }
         return new RubberDuck(el, collision, size, left, bottom, petRoot, floor, name, 4 /* PetSpeed.fast */);
     }
     else if (petType === 'zappy') {
-        if (name === undefined) {
-            name = getPetName(names_1.ZAPPY_NAMES, "zappy" /* PetType.zappy */, Zappy.count + 1);
-        }
         return new Zappy(el, collision, size, left, bottom, petRoot, floor, name, 5 /* PetSpeed.veryFast */);
     }
     else if (petType === 'rocky') {
-        if (name === undefined) {
-            name = getPetName(names_1.ROCKY_NAMES, "rocky" /* PetType.rocky */, Rocky.count + 1);
-        }
         return new Rocky(el, collision, size, left, bottom, petRoot, floor, name, 0 /* PetSpeed.still */);
     }
     throw new InvalidPetException();

--- a/media/main-bundle.js
+++ b/media/main-bundle.js
@@ -1536,7 +1536,7 @@ class InvalidPetException {
 }
 exports.InvalidPetException = InvalidPetException;
 function createPet(petType, el, collision, size, left, bottom, petRoot, floor, name) {
-    if (name === undefined) {
+    if (name === undefined || name === null || name === '') {
         throw new InvalidPetException('name is undefined');
     }
     if (petType === 'totoro') {

--- a/src/common/names.ts
+++ b/src/common/names.ts
@@ -1,3 +1,5 @@
+import { PetType } from './types';
+
 export const CAT_NAMES: Map<number, string> = new Map<number, string>([
     [1, 'Bella'],
     [2, 'Charlie'],
@@ -323,3 +325,48 @@ export const COCKATIEL_NAMES: Map<number, string> = new Map<number, string>([
     [13, 'Dame Judi Finch'],
     [14, 'Kanye Nest'],
 ]);
+
+export function randomName(type: PetType): string {
+    var collection: Map<number, string>;
+
+    switch (type) {
+        case PetType.cat:
+            collection = CAT_NAMES;
+            break;
+        case PetType.dog:
+            collection = DOG_NAMES;
+            break;
+        case PetType.crab:
+            collection = CRAB_NAMES;
+            break;
+        case PetType.clippy:
+            collection = CLIPPY_NAMES;
+            break;
+        case PetType.totoro:
+            collection = TOTORO_NAMES;
+            break;
+        case PetType.snake:
+            collection = SNAKE_NAMES;
+            break;
+        case PetType.rubberduck:
+            collection = DUCK_NAMES;
+            break;
+        case PetType.zappy:
+            collection = ZAPPY_NAMES;
+            break;
+        case PetType.rocky:
+            collection = ROCKY_NAMES;
+            break;
+        case PetType.cockatiel:
+            collection = COCKATIEL_NAMES;
+            break;
+        default:
+            collection = CAT_NAMES;
+            break;
+    }
+
+    return (
+        collection.get(Math.floor(Math.random() * collection.size) + 1) ??
+        'Unknown'
+    );
+}

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -109,11 +109,13 @@ export class PetSpecification {
     color: PetColor;
     type: PetType;
     size: PetSize;
+    name?: string;
 
-    constructor(color: PetColor, type: PetType, size: PetSize) {
+    constructor(color: PetColor, type: PetType, size: PetSize, name?: string) {
         this.color = color;
         this.type = type;
         this.size = size;
+        this.name = name;
     }
 
     static fromConfiguration(): PetSpecification {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -9,6 +9,18 @@ import {
     Theme,
     WebviewMessage,
 } from '../common/types';
+import {
+    CAT_NAMES,
+    DOG_NAMES,
+    COCKATIEL_NAMES,
+    CRAB_NAMES,
+    SNAKE_NAMES,
+    CLIPPY_NAMES,
+    TOTORO_NAMES,
+    DUCK_NAMES,
+    ZAPPY_NAMES,
+    ROCKY_NAMES,
+} from '../common/names';
 
 const EXTRA_PETS_KEY = 'vscode-pets.extra-pets';
 const EXTRA_PETS_KEY_TYPES = EXTRA_PETS_KEY + '.types';
@@ -241,6 +253,7 @@ async function handleRemovePetMessage(
                                 item.color,
                                 item.type,
                                 PetSize.medium,
+                                item.name,
                             );
                         });
                     storeCollectionAsMemento(this, collection);
@@ -460,10 +473,32 @@ export function activate(context: vscode.ExtensionContext) {
                         petColor = PetColor.yellow;
                         break;
                 }
+                const names = (
+                    {
+                        [PetType.cat]: CAT_NAMES,
+                        [PetType.dog]: DOG_NAMES,
+                        [PetType.cockatiel]: COCKATIEL_NAMES,
+                        [PetType.crab]: CRAB_NAMES,
+                        [PetType.snake]: SNAKE_NAMES,
+                        [PetType.clippy]: CLIPPY_NAMES,
+                        [PetType.totoro]: TOTORO_NAMES,
+                        [PetType.rubberduck]: DUCK_NAMES,
+                        [PetType.zappy]: ZAPPY_NAMES,
+                        [PetType.rocky]: ROCKY_NAMES,
+                    } as Record<PetType, Map<number, string>>
+                )[petType as PetType];
+                const name = await vscode.window.showInputBox({
+                    placeHolder: 'Leave blank for a random name',
+                    prompt: 'Name your pet',
+                    value: [...names.values()][
+                        Math.floor(Math.random() * names.size)
+                    ],
+                });
                 const spec = new PetSpecification(
                     petColor,
                     petType as PetType,
                     getConfiguredSize(),
+                    name,
                 );
                 if (
                     spec.type === null ||
@@ -775,6 +810,7 @@ class PetWebviewContainer implements IPetPanel {
             command: 'spawn-pet',
             type: spec.type,
             color: spec.color,
+            name: spec.name,
         });
         this.getWebview().postMessage({ command: 'set-size', size: spec.size });
     }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -9,18 +9,7 @@ import {
     Theme,
     WebviewMessage,
 } from '../common/types';
-import {
-    CAT_NAMES,
-    DOG_NAMES,
-    COCKATIEL_NAMES,
-    CRAB_NAMES,
-    SNAKE_NAMES,
-    CLIPPY_NAMES,
-    TOTORO_NAMES,
-    DUCK_NAMES,
-    ZAPPY_NAMES,
-    ROCKY_NAMES,
-} from '../common/names';
+import { randomName } from '../common/names';
 
 const EXTRA_PETS_KEY = 'vscode-pets.extra-pets';
 const EXTRA_PETS_KEY_TYPES = EXTRA_PETS_KEY + '.types';
@@ -122,13 +111,17 @@ export class PetSpecification {
     color: PetColor;
     type: PetType;
     size: PetSize;
-    name?: string;
+    name: string;
 
     constructor(color: PetColor, type: PetType, size: PetSize, name?: string) {
         this.color = color;
         this.type = type;
         this.size = size;
-        this.name = name;
+        if (!name) {
+            this.name = randomName(type);
+        } else {
+            this.name = name;
+        }
     }
 
     static fromConfiguration(): PetSpecification {
@@ -314,6 +307,8 @@ export function activate(context: vscode.ExtensionContext) {
                     collection.forEach((item) => {
                         PetPanel.currentPanel?.spawnPet(item);
                     });
+                    // Store the collection in the memento, incase any of the null values (e.g. name) have been set
+                    storeCollectionAsMemento(context, collection);
                 }
             }
         }),
@@ -458,26 +453,10 @@ export function activate(context: vscode.ExtensionContext) {
                         petColor = PetColor.yellow;
                         break;
                 }
-                const names = (
-                    {
-                        [PetType.cat]: CAT_NAMES,
-                        [PetType.dog]: DOG_NAMES,
-                        [PetType.cockatiel]: COCKATIEL_NAMES,
-                        [PetType.crab]: CRAB_NAMES,
-                        [PetType.snake]: SNAKE_NAMES,
-                        [PetType.clippy]: CLIPPY_NAMES,
-                        [PetType.totoro]: TOTORO_NAMES,
-                        [PetType.rubberduck]: DUCK_NAMES,
-                        [PetType.zappy]: ZAPPY_NAMES,
-                        [PetType.rocky]: ROCKY_NAMES,
-                    } as Record<PetType, Map<number, string>>
-                )[petType as PetType];
                 const name = await vscode.window.showInputBox({
                     placeHolder: 'Leave blank for a random name',
                     prompt: 'Name your pet',
-                    value: [...names.values()][
-                        Math.floor(Math.random() * names.size)
-                    ],
+                    value: randomName(petType as PetType),
                 });
                 const spec = new PetSpecification(
                     petColor,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -13,6 +13,7 @@ import {
 const EXTRA_PETS_KEY = 'vscode-pets.extra-pets';
 const EXTRA_PETS_KEY_TYPES = EXTRA_PETS_KEY + '.types';
 const EXTRA_PETS_KEY_COLORS = EXTRA_PETS_KEY + '.colors';
+const EXTRA_PETS_KEY_NAMES = EXTRA_PETS_KEY + '.names';
 const DEFAULT_PET_SCALE = PetSize.nano;
 const DEFAULT_COLOR = PetColor.brown;
 const DEFAULT_PET_TYPE = PetType.cat;
@@ -147,6 +148,10 @@ export class PetSpecification {
             EXTRA_PETS_KEY_COLORS,
             [],
         );
+        var contextNames = context.globalState.get<string[]>(
+            EXTRA_PETS_KEY_NAMES,
+            [],
+        );
         var result: PetSpecification[] = new Array();
         for (let index = 0; index < contextTypes.length; index++) {
             result.push(
@@ -154,6 +159,7 @@ export class PetSpecification {
                     contextColors?.[index] ?? DEFAULT_COLOR,
                     contextTypes[index],
                     size,
+                    contextNames[index],
                 ),
             );
         }
@@ -167,15 +173,19 @@ export function storeCollectionAsMemento(
 ) {
     var contextTypes = new Array(collection.length);
     var contextColors = new Array(collection.length);
+    var contextNames = new Array(collection.length);
     for (let index = 0; index < collection.length; index++) {
         contextTypes[index] = collection[index].type;
         contextColors[index] = collection[index].color;
+        contextNames[index] = collection[index].name;
     }
     context.globalState.update(EXTRA_PETS_KEY_TYPES, contextTypes);
     context.globalState.update(EXTRA_PETS_KEY_COLORS, contextColors);
+    context.globalState.update(EXTRA_PETS_KEY_NAMES, contextNames);
     context.globalState.setKeysForSync([
         EXTRA_PETS_KEY_TYPES,
         EXTRA_PETS_KEY_COLORS,
+        EXTRA_PETS_KEY_NAMES,
     ]);
 }
 

--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -372,7 +372,7 @@ export function petPanelApp(
                         randomStartPosition(),
                         floor,
                         floor,
-                        undefined,
+                        message.name,
                     ),
                 );
                 saveState();

--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -1,4 +1,5 @@
 // This script will be run within the webview itself
+import { randomName } from '../common/names';
 import {
     PetSize,
     PetColor,
@@ -106,7 +107,7 @@ function addPetToPanel(
     left: number,
     bottom: number,
     floor: number,
-    name: string | undefined,
+    name: string,
 ): PetElement {
     var petSpriteElement: HTMLImageElement = document.createElement('img');
     petSpriteElement.className = 'pet';
@@ -121,7 +122,7 @@ function addPetToPanel(
     );
 
     const root = basePetUri + '/' + petType + '/' + petColor;
-    console.log('Creating new pet : ', petType, root);
+    console.log('Creating new pet : ', petType, root, petColor, petSize, name);
     var newPet = createPet(
         petType,
         petSpriteElement,
@@ -188,7 +189,7 @@ function recoverState(basePetUri: string, petSize: PetSize, floor: number) {
                 parseInt(p.elLeft ?? '0'),
                 parseInt(p.elBottom ?? '0'),
                 floor,
-                p.petName,
+                p.petName ?? randomName(p.petType ?? PetType.cat),
             );
             allPets.push(newPet);
             recoveryMap.set(newPet.pet, p);
@@ -338,7 +339,7 @@ export function petPanelApp(
                 randomStartPosition(),
                 floor,
                 floor,
-                undefined,
+                randomName(petType),
             ),
         );
         saveState();
@@ -372,7 +373,7 @@ export function petPanelApp(
                         randomStartPosition(),
                         floor,
                         floor,
-                        message.name,
+                        message.name ?? randomName(message.type),
                     ),
                 );
                 saveState();

--- a/src/panel/pets.ts
+++ b/src/panel/pets.ts
@@ -973,7 +973,7 @@ export function createPet(
     floor: number,
     name: string,
 ): IPetType {
-    if (name === undefined) {
+    if (name === undefined || name === null || name === '') {
         throw new InvalidPetException('name is undefined');
     }
     if (petType === 'totoro') {

--- a/src/panel/pets.ts
+++ b/src/panel/pets.ts
@@ -11,18 +11,6 @@ import {
     PetInstanceState,
     isStateAboveGround,
 } from './states';
-import {
-    CAT_NAMES,
-    DOG_NAMES,
-    COCKATIEL_NAMES,
-    CRAB_NAMES,
-    SNAKE_NAMES,
-    CLIPPY_NAMES,
-    TOTORO_NAMES,
-    DUCK_NAMES,
-    ZAPPY_NAMES,
-    ROCKY_NAMES,
-} from '../common/names';
 
 export class InvalidStateException {}
 
@@ -966,17 +954,11 @@ export class Rocky extends BasePetType {
     }
 }
 
-export class InvalidPetException {}
+export class InvalidPetException {
+    message?: string;
 
-function getPetName(
-    collection: Map<number, string>,
-    label: string,
-    count: number,
-): string {
-    if (collection.has(count)) {
-        return collection.get(count) ?? label + count;
-    } else {
-        return label + count;
+    constructor(message?: string) {
+        this.message = message;
     }
 }
 
@@ -989,12 +971,12 @@ export function createPet(
     bottom: number,
     petRoot: string,
     floor: number,
-    name: string | undefined,
+    name: string,
 ): IPetType {
+    if (name === undefined) {
+        throw new InvalidPetException('name is undefined');
+    }
     if (petType === 'totoro') {
-        if (name === undefined) {
-            name = getPetName(TOTORO_NAMES, PetType.totoro, Totoro.count + 1);
-        }
         return new Totoro(
             el,
             collision,
@@ -1008,13 +990,6 @@ export function createPet(
         );
     }
     if (petType === 'cat') {
-        if (name === undefined) {
-            name = getPetName(
-                CAT_NAMES,
-                PetType.cat,
-                Cat.count + Dog.count + 1,
-            );
-        } // Cat and dog share the same name list
         return new Cat(
             el,
             collision,
@@ -1027,13 +1002,6 @@ export function createPet(
             PetSpeed.normal,
         );
     } else if (petType === 'dog') {
-        if (name === undefined) {
-            name = getPetName(
-                DOG_NAMES,
-                PetType.dog,
-                Dog.count + Cat.count + 1,
-            );
-        } // Cat and dog share the same name list
         return new Dog(
             el,
             collision,
@@ -1046,9 +1014,6 @@ export function createPet(
             PetSpeed.normal,
         );
     } else if (petType === 'snake') {
-        if (name === undefined) {
-            name = getPetName(SNAKE_NAMES, PetType.snake, Snake.count + 1);
-        }
         return new Snake(
             el,
             collision,
@@ -1061,9 +1026,6 @@ export function createPet(
             PetSpeed.verySlow,
         );
     } else if (petType === 'clippy') {
-        if (name === undefined) {
-            name = getPetName(CLIPPY_NAMES, PetType.clippy, Clippy.count + 1);
-        }
         return new Clippy(
             el,
             collision,
@@ -1076,13 +1038,6 @@ export function createPet(
             PetSpeed.slow,
         );
     } else if (petType === 'cockatiel') {
-        if (name === undefined) {
-            name = getPetName(
-                COCKATIEL_NAMES,
-                PetType.cockatiel,
-                Cockatiel.count + 1,
-            );
-        }
         return new Cockatiel(
             el,
             collision,
@@ -1095,9 +1050,6 @@ export function createPet(
             PetSpeed.normal,
         );
     } else if (petType === 'crab') {
-        if (name === undefined) {
-            name = getPetName(CRAB_NAMES, PetType.crab, Crab.count + 1);
-        }
         return new Crab(
             el,
             collision,
@@ -1110,13 +1062,6 @@ export function createPet(
             PetSpeed.slow,
         );
     } else if (petType === 'rubber-duck') {
-        if (name === undefined) {
-            name = getPetName(
-                DUCK_NAMES,
-                PetType.rubberduck,
-                RubberDuck.count + 1,
-            );
-        }
         return new RubberDuck(
             el,
             collision,
@@ -1129,9 +1074,6 @@ export function createPet(
             PetSpeed.fast,
         );
     } else if (petType === 'zappy') {
-        if (name === undefined) {
-            name = getPetName(ZAPPY_NAMES, PetType.zappy, Zappy.count + 1);
-        }
         return new Zappy(
             el,
             collision,
@@ -1144,9 +1086,6 @@ export function createPet(
             PetSpeed.veryFast,
         );
     } else if (petType === 'rocky') {
-        if (name === undefined) {
-            name = getPetName(ROCKY_NAMES, PetType.rocky, Rocky.count + 1);
-        }
         return new Rocky(
             el,
             collision,


### PR DESCRIPTION
Resolves #173.

I added an additional step to the `vscode-pets.spawn-pet` command, which allows the user to input any name they want for their pets.

It automatically suggests a random name from the appropriate list (according to the corresponding `PetType`) and pre-selects it, so the user may just start typing to overwrite the suggestion.
Leaving the field blank behaves as previously, generating a random name for the new pet.