### PR TITLE
Add a custom hello message for cat

### DIFF
--- a/src/panel/pets.ts
+++ b/src/panel/pets.ts
@@ -589,8 +589,7 @@ export class Cat extends BasePetType {
         return '🐱';
     }
     hello(): string {
-        // TODO: #185 Add a custom message for cat
-        return ` says hello 👋!`;
+        return `brrr... Meow!`;
     }
 }
 


### PR DESCRIPTION
Fixes #185 

Created a custom hello message for a cat.

Based on this [article](https://www.insider.com/what-cat-sounds-mean-2018-10#a-trill-is-your-cats-way-of-saying-hello-6), cats thrill when they say hello, so I added the brrr sound. 

Was: ` says hello 👋!`
Now:  `brrr... Meow!`

Let me know if you want any additional changes.