### PR TITLE
Change PetCollection.pets to be a getter

### DIFF
--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -80,7 +80,7 @@ function calculateFloor(size: PetSize, theme: Theme): number {
 
 function handleMouseOver(e: MouseEvent) {
     var el = e.currentTarget as HTMLDivElement;
-    allPets.pets().forEach((element) => {
+    allPets.pets.forEach((element) => {
         if (element.collision === el) {
             if (!element.pet.canSwipe()) {
                 return;
@@ -185,7 +185,7 @@ export function saveState(stateApi?: VscodeStateApi) {
     var state = new PetPanelState();
     state.petStates = new Array();
 
-    allPets.pets().forEach((petItem) => {
+    allPets.pets.forEach((petItem) => {
         state.petStates?.push({
             petName: petItem.pet.name(),
             petColor: petItem.color,
@@ -420,7 +420,7 @@ export function petPanelApp(
             case 'throw-ball':
                 resetBall();
                 throwBall();
-                allPets.pets().forEach((petEl) => {
+                allPets.pets.forEach((petEl) => {
                     if (petEl.pet.canChase()) {
                         petEl.pet.chase(ballState, canvas);
                     }
@@ -444,7 +444,7 @@ export function petPanelApp(
                 break;
 
             case 'list-pets':
-                var pets = allPets.pets();
+                var pets = allPets.pets;
                 stateApi?.postMessage({
                     command: 'list-pets',
                     text: pets
@@ -457,7 +457,7 @@ export function petPanelApp(
                 break;
 
             case 'roll-call':
-                var pets = allPets.pets();
+                var pets = allPets.pets;
                 // go through every single
                 // pet and then print out their name
                 pets.forEach((pet) => {

--- a/src/panel/pets.ts
+++ b/src/panel/pets.ts
@@ -47,7 +47,7 @@ export class PetElement {
 }
 
 export interface IPetCollection {
-    pets(): Array<PetElement>;
+    pets: Array<PetElement>;
     push(pet: PetElement): void;
     reset(): void;
     seekNewFriends(): string[];
@@ -62,7 +62,7 @@ export class PetCollection implements IPetCollection {
         this._pets = new Array(0);
     }
 
-    pets() {
+    public get pets() {
         return this._pets;
     }
 

--- a/src/test/suite/panel.test.ts
+++ b/src/test/suite/panel.test.ts
@@ -147,7 +147,7 @@ suite('Pets Test Suite', () => {
                 assert.equal(firstPet.petType, petType);
                 assert.equal(firstPet.petColor, PetColor.black);
 
-                const createdPets = panel.allPets.pets();
+                const createdPets = panel.allPets.pets;
                 assert.notEqual(createdPets.at(0), undefined);
 
                 assert.equal(createdPets.at(0)?.color, PetColor.black);


### PR DESCRIPTION
By using a getter, `pets` on `allPets` can be accessed using `.pets` rather than needing to call it as a method (`.pets()`).

This can be done for similar methods on the other classes in this file, but I didn't want to throw it at you as one big PR, so I'm breaking it up for clarity.