### PR TITLE
Change relevant pet fields to getters

### DIFF
--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -82,7 +82,7 @@ function handleMouseOver(e: MouseEvent) {
     var el = e.currentTarget as HTMLDivElement;
     allPets.pets().forEach((element) => {
         if (element.collision === el) {
-            if (!element.pet.canSwipe()) {
+            if (!element.pet.canSwipe) {
                 return;
             }
             element.pet.swipe();
@@ -187,11 +187,11 @@ export function saveState(stateApi?: VscodeStateApi) {
 
     allPets.pets().forEach((petItem) => {
         state.petStates?.push({
-            petName: petItem.pet.name(),
+            petName: petItem.pet.name,
             petColor: petItem.color,
             petType: petItem.type,
             petState: petItem.pet.getState(),
-            petFriend: petItem.pet.friend()?.name() ?? undefined,
+            petFriend: petItem.pet.friend?.name ?? undefined,
             elLeft: petItem.el.style.left,
             elBottom: petItem.el.style.bottom,
         });
@@ -421,7 +421,7 @@ export function petPanelApp(
                 resetBall();
                 throwBall();
                 allPets.pets().forEach((petEl) => {
-                    if (petEl.pet.canChase()) {
+                    if (petEl.pet.canChase) {
                         petEl.pet.chase(ballState, canvas);
                     }
                 });
@@ -449,8 +449,7 @@ export function petPanelApp(
                     command: 'list-pets',
                     text: pets
                         .map(
-                            (pet) =>
-                                `${pet.type},${pet.pet.name()},${pet.color}`,
+                            (pet) => `${pet.type},${pet.pet.name},${pet.color}`,
                         )
                         .join('\n'),
                 });
@@ -463,9 +462,7 @@ export function petPanelApp(
                 pets.forEach((pet) => {
                     stateApi?.postMessage({
                         command: 'info',
-                        text: `${pet.pet.emoji()} ${pet.pet.name()} (${
-                            pet.color
-                        } ${pet.type}): ${pet.pet.hello()}`,
+                        text: `${pet.pet.emoji} ${pet.pet.name} (${pet.color} ${pet.type}): ${pet.pet.hello}`,
                     });
                 });
             case 'delete-pet':

--- a/src/panel/pets.ts
+++ b/src/panel/pets.ts
@@ -255,11 +255,11 @@ abstract class BasePetType implements IPetType {
         this.hideSpeechBubble();
     }
 
-    public get left(): number {
+    get left(): number {
         return this._left;
     }
 
-    public get bottom(): number {
+    get bottom(): number {
         return this._bottom;
     }
 

--- a/src/panel/pets.ts
+++ b/src/panel/pets.ts
@@ -79,18 +79,18 @@ export class PetCollection implements IPetCollection {
 
     locate(name: string): PetElement | undefined {
         return this._pets.find((collection) => {
-            return collection.pet.name() === name;
+            return collection.pet.name === name;
         });
     }
 
     remove(name: string): any {
         this._pets.forEach((pet) => {
-            if (pet.pet.name() === name) {
+            if (pet.pet.name === name) {
                 pet.remove();
             }
         });
         this._pets = this._pets.filter((pet) => {
-            return pet.pet.name() !== name;
+            return pet.pet.name !== name;
         });
     }
 
@@ -100,26 +100,26 @@ export class PetCollection implements IPetCollection {
         } // You can't be friends with yourself.
         var messages = new Array<string>(0);
         this._pets.forEach((petInCollection) => {
-            if (petInCollection.pet.hasFriend()) {
+            if (petInCollection.pet.hasFriend) {
                 return;
             } // I already have a friend!
             this._pets.forEach((potentialFriend) => {
-                if (potentialFriend.pet.hasFriend()) {
+                if (potentialFriend.pet.hasFriend) {
                     return;
                 } // Already has a friend. sorry.
-                if (!potentialFriend.pet.canChase()) {
+                if (!potentialFriend.pet.canChase) {
                     return;
                 } // Pet is busy doing something else.
                 if (
-                    potentialFriend.pet.left() > petInCollection.pet.left() &&
-                    potentialFriend.pet.left() <
-                        petInCollection.pet.left() + petInCollection.pet.width()
+                    potentialFriend.pet.left > petInCollection.pet.left &&
+                    potentialFriend.pet.left <
+                        petInCollection.pet.left + petInCollection.pet.width
                 ) {
                     // We found a possible new friend..
                     console.log(
-                        petInCollection.pet.name(),
+                        petInCollection.pet.name,
                         ' wants to be friends with ',
-                        potentialFriend.pet.name(),
+                        potentialFriend.pet.name,
                         '.',
                     );
                     if (
@@ -139,13 +139,13 @@ export interface IPetType {
     nextFrame(): void;
 
     // Special methods for actions
-    canSwipe(): boolean;
-    canChase(): boolean;
+    canSwipe: boolean;
+    canChase: boolean;
     swipe(): void;
     chase(ballState: BallState, canvas: HTMLCanvasElement): void;
-    speed(): number;
-    isMoving(): boolean;
-    hello(): string;
+    speed: number;
+    isMoving: boolean;
+    hello: string;
 
     // State API
     getState(): PetInstanceState;
@@ -153,20 +153,20 @@ export interface IPetType {
     recoverFriend(friend: IPetType): void;
 
     // Positioning
-    bottom(): number;
-    left(): number;
+    bottom: number;
+    left: number;
     positionBottom(bottom: number): void;
     positionLeft(left: number): void;
-    width(): number;
-    floor(): number;
+    width: number;
+    floor: number;
 
     // Friends API
-    name(): string;
-    emoji(): string;
-    hasFriend(): boolean;
-    friend(): IPetType | undefined;
+    name: string;
+    emoji: string;
+    hasFriend: boolean;
+    friend: IPetType | undefined;
     makeFriendsWith(friend: IPetType): boolean;
-    isPlaying(): boolean;
+    isPlaying: boolean;
 
     showSpeechBubble(message: string, duration: number): void;
 }
@@ -255,11 +255,11 @@ abstract class BasePetType implements IPetType {
         this.hideSpeechBubble();
     }
 
-    left(): number {
+    public get left(): number {
         return this._left;
     }
 
-    bottom(): number {
+    public get bottom(): number {
         return this._bottom;
     }
 
@@ -284,15 +284,15 @@ abstract class BasePetType implements IPetType {
         this.repositionAccompanyingElements();
     }
 
-    width(): number {
+    get width(): number {
         return this.el.width;
     }
 
-    floor(): number {
+    get floor(): number {
         return this._floor;
     }
 
-    hello(): string {
+    get hello(): string {
         // return the sound of the name of the animal
         return ` says hello 👋!`;
     }
@@ -301,7 +301,7 @@ abstract class BasePetType implements IPetType {
         return { currentStateEnum: this.currentStateEnum };
     }
 
-    speed(): number {
+    get speed(): number {
         return this._speed;
     }
 
@@ -312,7 +312,7 @@ abstract class BasePetType implements IPetType {
         return newSpeed;
     }
 
-    isMoving(): boolean {
+    get isMoving(): boolean {
         return this._speed !== PetSpeed.still;
     }
 
@@ -330,19 +330,19 @@ abstract class BasePetType implements IPetType {
         if (!isStateAboveGround(this.currentStateEnum)) {
             // Reset the bottom of the sprite to the floor as the theme
             // has likely changed.
-            this.positionBottom(this.floor());
+            this.positionBottom(this.floor);
         }
     }
 
-    canSwipe() {
+    get canSwipe() {
         return !isStateAboveGround(this.currentStateEnum);
     }
 
-    canChase() {
+    get canChase() {
         return (
             !isStateAboveGround(this.currentStateEnum) &&
             this.currentStateEnum !== States.chase &&
-            this.isMoving()
+            this.isMoving
         );
     }
 
@@ -420,12 +420,12 @@ abstract class BasePetType implements IPetType {
 
         // What's my buddy doing?
         if (
-            this.hasFriend() &&
+            this.hasFriend &&
             this.currentStateEnum !== States.chaseFriend &&
-            this.isMoving()
+            this.isMoving
         ) {
             if (
-                this.friend()?.isPlaying() &&
+                this.friend?.isPlaying &&
                 !isStateAboveGround(this.currentStateEnum)
             ) {
                 this.currentState = resolveState(States.chaseFriend, this);
@@ -461,33 +461,33 @@ abstract class BasePetType implements IPetType {
         }
     }
 
-    hasFriend(): boolean {
+    get hasFriend(): boolean {
         return this._friend !== undefined;
     }
 
-    friend(): IPetType | undefined {
+    get friend(): IPetType | undefined {
         return this._friend;
     }
 
-    name(): string {
+    get name(): string {
         return this._name;
     }
 
     makeFriendsWith(friend: IPetType): boolean {
         this._friend = friend;
-        console.log(this.name(), ": I'm now friends ❤️ with ", friend.name());
+        console.log(this.name, ": I'm now friends ❤️ with ", friend.name);
         return true;
     }
 
-    isPlaying(): boolean {
+    get isPlaying(): boolean {
         return (
-            this.isMoving() &&
+            this.isMoving &&
             (this.currentStateEnum === States.runRight ||
                 this.currentStateEnum === States.runLeft)
         );
     }
 
-    emoji(): string {
+    get emoji(): string {
         return '🐶';
     }
 }
@@ -547,10 +547,10 @@ export class Totoro extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '🐾';
     }
-    hello(): string {
+    get hello(): string {
         return `Try Laughing. Then Whatever Scares You Will Go Away. 🎭`;
     }
 }
@@ -624,10 +624,10 @@ export class Cat extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '🐱';
     }
-    hello(): string {
+    get hello(): string {
         return `brrr... Meow!`;
     }
 }
@@ -690,10 +690,10 @@ export class Dog extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '🐶';
     }
-    hello(): string {
+    get hello(): string {
         return ` Every dog has its day - and today is woof day! Today I just want to bark. Take me on a walk`;
     }
 }
@@ -746,10 +746,10 @@ export class Snake extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '🐍';
     }
-    hello(): string {
+    get hello(): string {
         return `Sss... Oh. Oh my gosh! I'm a snake!`;
     }
 }
@@ -794,10 +794,10 @@ export class Clippy extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '📎';
     }
-    hello(): string {
+    get hello(): string {
         return ` Hi, I'm Clippy, would you like some assistance today? 👋!`;
     }
 }
@@ -842,10 +842,10 @@ export class RubberDuck extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '🐥';
     }
-    hello(): string {
+    get hello(): string {
         return ` Hi, I love to quack around 👋!`;
     }
 }
@@ -890,10 +890,10 @@ export class Cockatiel extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '🦜';
     }
-    hello(): string {
+    get hello(): string {
         // TODO: #191 Add a custom message for cockatiel
         return ` Hello, I'm a good bird 👋!`;
     }
@@ -939,10 +939,10 @@ export class Crab extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '🦀';
     }
-    hello(): string {
+    get hello(): string {
         return ` Hi, I'm Crabsolutely Clawsome Crab 👋!`;
     }
 }
@@ -987,10 +987,10 @@ export class Zappy extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '⚡';
     }
-    hello(): string {
+    get hello(): string {
         // TODO: #193 Add a custom message for zappy
         return ` Hello this is Zappy! Do I look familiar?? I am the mascot for Azure Functions😉`;
     }
@@ -1015,13 +1015,13 @@ export class Rocky extends BasePetType {
             },
         ],
     };
-    emoji(): string {
+    get emoji(): string {
         return '💎';
     }
-    canChase(): boolean {
+    get canChase(): boolean {
         return false;
     }
-    hello(): string {
+    get hello(): string {
         return ` 👋 I'm rock! I always Rock`;
     }
 }

--- a/src/panel/states.ts
+++ b/src/panel/states.ts
@@ -199,14 +199,14 @@ export class WalkRightState implements IState {
     nextFrame(): FrameResult {
         this.idleCounter++;
         this.pet.positionLeft(
-            this.pet.left() + this.pet.speed() * this.speedMultiplier,
+            this.pet.left + this.pet.speed * this.speedMultiplier,
         );
         if (
-            this.pet.isMoving() &&
-            this.pet.left() >= this.leftBoundary - this.pet.width()
+            this.pet.isMoving &&
+            this.pet.left >= this.leftBoundary - this.pet.width
         ) {
             return FrameResult.stateComplete;
-        } else if (!this.pet.isMoving() && this.idleCounter > this.holdTime) {
+        } else if (!this.pet.isMoving && this.idleCounter > this.holdTime) {
             return FrameResult.stateComplete;
         }
         return FrameResult.stateContinue;
@@ -229,11 +229,11 @@ export class WalkLeftState implements IState {
 
     nextFrame(): FrameResult {
         this.pet.positionLeft(
-            this.pet.left() - this.pet.speed() * this.speedMultiplier,
+            this.pet.left - this.pet.speed * this.speedMultiplier,
         );
-        if (this.pet.isMoving() && this.pet.left() <= 0) {
+        if (this.pet.isMoving && this.pet.left <= 0) {
             return FrameResult.stateComplete;
-        } else if (!this.pet.isMoving() && this.idleCounter > this.holdTime) {
+        } else if (!this.pet.isMoving && this.idleCounter > this.holdTime) {
             return FrameResult.stateComplete;
         }
         return FrameResult.stateContinue;
@@ -276,19 +276,19 @@ export class ChaseState implements IState {
         if (this.ballState.paused) {
             return FrameResult.stateCancel; // Ball is already caught
         }
-        if (this.pet.left() > this.ballState.cx) {
+        if (this.pet.left > this.ballState.cx) {
             this.horizontalDirection = HorizontalDirection.left;
-            this.pet.positionLeft(this.pet.left() - this.pet.speed());
+            this.pet.positionLeft(this.pet.left - this.pet.speed);
         } else {
             this.horizontalDirection = HorizontalDirection.right;
-            this.pet.positionLeft(this.pet.left() + this.pet.speed());
+            this.pet.positionLeft(this.pet.left + this.pet.speed);
         }
 
         if (
             this.canvas.height - this.ballState.cy <
-                this.pet.width() + this.pet.floor() &&
-            this.ballState.cx < this.pet.left() &&
-            this.pet.left() < this.ballState.cx + 15
+                this.pet.width + this.pet.floor &&
+            this.ballState.cx < this.pet.left &&
+            this.pet.left < this.ballState.cx + 15
         ) {
             // hide ball
             this.canvas.style.display = 'none';
@@ -310,16 +310,16 @@ export class ChaseFriendState implements IState {
     }
 
     nextFrame(): FrameResult {
-        if (!this.pet.hasFriend() || !this.pet.friend()?.isPlaying()) {
+        if (!this.pet.hasFriend || !this.pet.friend?.isPlaying) {
             return FrameResult.stateCancel; // Friend is no longer playing.
         }
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        if (this.pet.left() > this.pet.friend()!.left()) {
+        if (this.pet.left > this.pet.friend!.left) {
             this.horizontalDirection = HorizontalDirection.left;
-            this.pet.positionLeft(this.pet.left() - this.pet.speed());
+            this.pet.positionLeft(this.pet.left - this.pet.speed);
         } else {
             this.horizontalDirection = HorizontalDirection.right;
-            this.pet.positionLeft(this.pet.left() + this.pet.speed());
+            this.pet.positionLeft(this.pet.left + this.pet.speed);
         }
 
         return FrameResult.stateContinue;
@@ -337,8 +337,8 @@ export class ClimbWallLeftState implements IState {
     }
 
     nextFrame(): FrameResult {
-        this.pet.positionBottom(this.pet.bottom() + 1);
-        if (this.pet.bottom() >= 100) {
+        this.pet.positionBottom(this.pet.bottom + 1);
+        if (this.pet.bottom >= 100) {
             return FrameResult.stateComplete;
         }
         return FrameResult.stateContinue;
@@ -356,9 +356,9 @@ export class JumpDownLeftState implements IState {
     }
 
     nextFrame(): FrameResult {
-        this.pet.positionBottom(this.pet.bottom() - 5);
-        if (this.pet.bottom() <= this.pet.floor()) {
-            this.pet.positionBottom(this.pet.floor());
+        this.pet.positionBottom(this.pet.bottom - 5);
+        if (this.pet.bottom <= this.pet.floor) {
+            this.pet.positionBottom(this.pet.floor);
             return FrameResult.stateComplete;
         }
         return FrameResult.stateContinue;

--- a/src/test/suite/panel.test.ts
+++ b/src/test/suite/panel.test.ts
@@ -93,8 +93,8 @@ suite('Pets Test Suite', () => {
             'Jerry',
         );
         assert.ok(testPet instanceof pets.Cat);
-        assert.equal(testPet.emoji(), '🐱');
-        assert.equal(testPet.name(), 'Jerry');
+        assert.equal(testPet.emoji, '🐱');
+        assert.equal(testPet.name, 'Jerry');
 
         const testPetElement = new pets.PetElement(
             petImageEl,


### PR DESCRIPTION
For pet type class methods that just return private values, replace the methods with getter methods so that the fields can be accessed on the pets without parentheses.

E.g. `pet.name` instead of `pet.name()`

This is a followup to https://github.com/tonybaloney/vscode-pets/pull/285