### PR TITLE
Setup Crowdin

### DIFF
--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,0 +1,43 @@
+# This workflow will run Crowdin Action that will upload new texts to Crowdin, download the newest translations and create a PR
+# For more information see: https://github.com/crowdin/github-action
+
+name: Localization
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # Every 6 hours - https://crontab.guru/#0_*/6_*_*_*
+  push:
+    branches: [ master, feat/setup-crowdin ]
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: crowdin action
+        uses: crowdin/github-action@1.5.0
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+
+          # Upload translations to Crowdin, only use true at initial run
+          upload_translations: true
+
+          # Make pull request of Crowdin translations
+          download_translations: true
+
+          # To download translations to the specified version branch
+          localization_branch_name: l10n_crowdin_translations
+
+          # Create pull request after pushing to branch
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'New Crowdin pull request with translations'
+          pull_request_base_branch_name: 'master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .build-out/
 coverage/
 .nyc_output/
+.idea/

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,12 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "."
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "package.nls.json",
+    "translation": "package.nls.%two_letters_code%.json"
+  }
+]


### PR DESCRIPTION
Hey everyone,

Recently I found this extension and now it's my favorite VS Code Extension ever 😍 

![image](https://user-images.githubusercontent.com/29282228/201068132-d4a4131d-34b2-4d44-8daa-e0ef3ab1e4a7.png)

Just did some analysis of the current i18n workflow and it feels like GitHub issues and PRs reported by the community are not so easy to handle. The community translators can work together in Crowdin, translations would be delivered as PR and volunteers can raise issues for problematic strings via Crowdin.

I'm suggesting the integration with Crowdin via GitHub Actions. Crowdin is **free for open-source** projects. This integration works in the following way:

- the action runs every 6 hours (actually, it's up to you what trigger to use, it could also be a push to the default branch, for example)
- upload new source texts to the Crowdin project
- upload existing translations to Crowdin
- download all the new translations from Crowdin, commit changes and open a Pull Request.

You can find my demo Crowdin project here - [vs-code-pets-demo](https://crowdin.com/project/vs-code-pets-demo).

Example of the first PR that will be created by the Action - [here](https://github.com/andrii-bodnar/vscode-pets/pull/1/commits/02a89c273b8d033c5fe51c93180a4347d86bcaca) (Don't worry about the diffs - it's just updated the translation files to the actual state. The next PRs will include the new translations only).

Also, I would be happy to contribute to Ukrainian translations 🇺🇦 
