### PR TITLE
Ignore node_modules from bundled VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,4 @@ src/**
 .build-out/
 coverage/
 docs/
+node_modules

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-pets",
     "displayName": "vscode-pets",
     "description": "Pets for your VS Code",
-    "version": "1.19.2-beta1",
+    "version": "1.19.2",
     "engines": {
         "vscode": "^1.73.0"
     },


### PR DESCRIPTION
Should reduce bundled VSIX size. 