### PR TITLE
CI is now using node v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [14.x]
+                node-version: [18.x]
         steps:
             - uses: actions/checkout@v2
             - name: Use Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-pets",
-    "version": "1.24.0",
+    "version": "1.25.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-pets",
-            "version": "1.24.0",
+            "version": "1.25.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/l10n": "^0.0.10"


### PR DESCRIPTION
## What does this PR do?
- This PR changes the CI Node version from v14 to 18

## Issue number: #473 