### PR TITLE
Fix broken link to subsection

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -21,7 +21,7 @@ Once you have the pet panel open, you can:
 * :ref:`Throwing a ball`
 * :ref:`Roll-call with your pets`
 * :ref:`Removing a single pet or multiple pets`
-* :ref `Importing or Exporting your Pet List`
+* :ref:`Importing or Exporting your Pet List`
 * :ref:`Themes`
 
 Changing your pet


### PR DESCRIPTION
Fixing missing colon causing "Importing or Exporting your Pet List" not to link to subsection.