### PR TITLE
Add orange cat

### DIFF
--- a/src/panel/pets/cat.ts
+++ b/src/panel/pets/cat.ts
@@ -7,9 +7,10 @@ export class Cat extends BasePetType {
     static possibleColors = [
         PetColor.black,
         PetColor.brown,
-        PetColor.white,
         PetColor.gray,
         PetColor.lightbrown,
+        PetColor.orange,
+        PetColor.white,
     ];
     sequence = {
         startingState: States.sitIdle,

--- a/src/panel/pets/cat.ts
+++ b/src/panel/pets/cat.ts
@@ -207,4 +207,5 @@ export const CAT_NAMES: ReadonlyArray<string> = [
     'Carlotta',
     'Felix',
     'Duchess',
+    'Byrt',
 ];

--- a/src/test/gifs.ts
+++ b/src/test/gifs.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 
 const pets: { [key: string]: { colors: string[]; states: string[] } } = {
     cat: {
-        colors: ['black', 'brown', 'gray', 'lightbrown', 'white'],
+        colors: ['black', 'brown', 'gray', 'lightbrown', 'orange', 'white'],
         states: [
             'fall_from_grab',
             'idle',


### PR DESCRIPTION
Hello! I would like to add an orange cat to the cat options. I know the cat assets can't be distributed so I didn't include any asset files in my commits. I'm wondering if this workaround would be ok: 

1. I bought the cat assets from seethingswarm and modified the lightbrown cat to be orange. 
2. I can send you the orange cat assets separately or encrypted? 

Let me know what you think!