### PR TITLE
Use code instead of citations

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -37,7 +37,7 @@ Want to contribute to vscode-pets? Feel free to `fork the repository <https://gi
 Drawing and Animations
 ++++++++++++++++++++++
 
-If you want to contribute improvements to the animations, additional pet colors or even new pets, clone the repository and work in the `media/` folder.  
+If you want to contribute improvements to the animations, additional pet colors or even new pets, clone the repository and work in the ``media/`` folder.  
 
 Most drawings are done in `aseprite <https://www.aseprite.org/>`_ because you can edit GIFs directly. However, you are free to use any tool to make the animations. Animations should be 8 frames per second. The style of the extension is to have pixelated creatures (although not limited to an 8-bit color canvas).  
 
@@ -53,13 +53,13 @@ The minimum set of behaviors is:
 Testing the changes
 +++++++++++++++++++
 
--   Run `npm install`.
--   Run `npm run compile`.
+-   Run ``npm install``.
+-   Run ``npm run compile``.
 -   Go to the debug panel on the sidebar and launch the development version with the extension loaded (first option in the debug profiles).
 -   Refer to `VS Code Extension Documentation <https://code.visualstudio.com/api>`_ for additional resources.
 
 Submitting a PR
 +++++++++++++++
 
-- Please make sure to run `npm run lint` and verify there are no errors/warnings. 
-- You can run `npm run lint:fix` to fix the lint issues. 
+- Please make sure to run ``npm run lint`` and verify there are no errors/warnings. 
+- You can run ``npm run lint:fix`` to fix the lint issues. 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,19 +26,19 @@ Install this extension from the `VS Code marketplace <https://marketplace.visual
 From VS Code
 ++++++++++++
 
-With VS Code open, search for `vscode-pets` in the extension panel (`Ctrl+Shift+X` on Windows/Linux or `Cmd(⌘)+Shift+X` on MacOS) and click install.
+With VS Code open, search for ``vscode-pets`` in the extension panel (``Ctrl+Shift+X`` on Windows/Linux or ``Cmd(⌘)+Shift+X`` on MacOS) and click install.
 
 .. image:: _static/install.png
    :alt: Installation screenshot
 
-Alternatively, with VS Code open, launch VS Code Quick Open (`Ctrl+P` on Windows/Linux or `Cmd(⌘)+P` on MacOS), paste the following command, and press enter.
+Alternatively, with VS Code open, launch VS Code Quick Open (``Ctrl+P`` on Windows/Linux or ``Cmd(⌘)+P`` on MacOS), paste the following command, and press enter.
 
-`ext install tonybaloney.vscode-pets`
+``ext install tonybaloney.vscode-pets``
 
 Getting Started
 ---------------
 
-Launch VS Code Command Palette (`Ctrl+Shift+P` on Windows/Linux or `Cmd(⌘)+Shift+P` on MacOS, then type `pets` and select `Pets: Start Pet Coding Session`.
+Launch VS Code Command Palette (``Ctrl+Shift+P`` on Windows/Linux or ``Cmd(⌘)+Shift+P`` on MacOS, then type ``pets`` and select ``Pets: Start Pet Coding Session``.
 
 .. image:: _static/start_pet_coding.png
    :alt: Start screenshot

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -8,9 +8,9 @@ Not convinced? Watch our extension spotlight on `Visual Studio Code <https://www
 Start pet coding session to show your pet
 -----------------------------------------
 
-Open the command palette with `Ctrl+Shift+P` on Windows/Linux or `Cmd(⌘)+Shift+P` on MacOS.  
+Open the command palette with ``Ctrl+Shift+P`` on Windows/Linux or ``Cmd(⌘)+Shift+P`` on MacOS.  
 
-Run the "Start pet coding session" command (`vscode-pets.start`)
+Run the "Start pet coding session" command (``vscode-pets.start``)
 
 Once you have the pet panel open, you can:
 
@@ -27,7 +27,7 @@ Once you have the pet panel open, you can:
 Changing your pet
 -----------------
 
-Open the setting panel with `Ctrl+,` on Windows/Linux or `Cmd(⌘)+,` on MacOS. In the search bar, enter “vscode-pets” to see all available options.
+Open the setting panel with ``Ctrl+,`` on Windows/Linux or ``Cmd(⌘)+,`` on MacOS. In the search bar, enter “vscode-pets” to see all available options.
 
 Set a default color, size, pet type, position, and theme when you open a Pet Panel.
 
@@ -50,8 +50,8 @@ Restrictions
 Place the pet's window
 ----------------------
 
-To switch the pet's window between *explorer (default)* and *panel*, you can use the command `vscode-pets.position`.
-Or in the setting panel the option `Position`.
+To switch the pet's window between *explorer (default)* and *panel*, you can use the command ``vscode-pets.position``.
+Or in the setting panel the option ``Position``.
 
 .. image:: _static/position-setting.png
 
@@ -73,7 +73,7 @@ Pets will interact with your mouse pointer within the open Pet Panel. Additional
 Adding additional pets
 ----------------------
 
-To add additional pets, run the "Spawn additional pet" command (`vscode-pets.spawn-pet`) or click the `+` icon.
+To add additional pets, run the "Spawn additional pet" command (``vscode-pets.spawn-pet``) or click the ``+`` icon.
 
 .. image:: _static/add-pet.png
 
@@ -92,11 +92,11 @@ Play catch with your pet! Click the ball icon in the VS Code Pets panel to throw
 
 .. image:: _static/throw-ball.gif
 
-You can also use the "Throw ball" command (`vscode-pets.throw-ball`).
+You can also use the "Throw ball" command (``vscode-pets.throw-bal`l`).
 
 * Rocky will not run & catch a ball. Have you ever seen a rock run after a ball? Neither have we.
 
-Want to challenge your pets to a harder game of fetch? Enable the "Throw ball with mouse" (`vscode-pets.throwBallWithMouse`) option in the settings. 
+Want to challenge your pets to a harder game of fetch? Enable the "Throw ball with mouse" (``vscode-pets.throwBallWithMouse``) option in the settings. 
 Then use the mouse to click and throw the ball:
 
 .. image:: _static/throw-ball-with-mouse.gif
@@ -104,16 +104,16 @@ Then use the mouse to click and throw the ball:
 Roll-call with your pets
 ------------------------
 
-Get a description of your current pets within VS Code. Run the "Roll-call" command (`vscode-pets.roll-call`) from the command palette.
+Get a description of your current pets within VS Code. Run the "Roll-call" command (``vscode-pets.roll-call``) from the command palette.
 
 .. image:: _static/pet-roll-call.png
 
 Removing a single pet or multiple pets
 --------------------------------------
 
-You can remove all pets (except the 1 configured) by running the "Remove all pets" command (`vscode-pets.delete-pets`) from the command palette.
+You can remove all pets (except the 1 configured) by running the "Remove all pets" command (``vscode-pets.delete-pets``) from the command palette.
 
-You can remove specific pets by clicking the trashcan icon or by running the "Remove pet" command (`vscode-pets.delete-pet`) from the command palette.
+You can remove specific pets by clicking the trashcan icon or by running the "Remove pet" command (``vscode-pets.delete-pet``) from the command palette.
 
 .. image:: _static/pet-remove.png
 
@@ -121,8 +121,8 @@ Importing or Exporting your Pet List
 ------------------------------------
 
 Have a certain pet setup you would like to share with your friends?
-You can export your pet list by running the "Export pet list" command (`vscode-pets.export-pets`) from the command palette.
-The pet list can be imported by running the "Import pet list" command (`vscode-pets.import-pets`) from the command palette.
+You can export your pet list by running the "Export pet list" command (``vscode-pets.export-pets``) from the command palette.
+The pet list can be imported by running the "Import pet list" command (``vscode-pets.import-pets``) from the command palette.
 
 .. image:: _static/pet-import-export.gif
 
@@ -131,14 +131,14 @@ Themes
 
 VS Code Pets comes with themes. Themes are set from the VS Code Preferences Window. Search for "vscode-pets" to find the VS Code Pets specific settings.
 
-Configure `vscode-pets.theme` to `"forest"` and let your pets play in a spooky forest.
+Configure ``vscode-pets.theme`` to ``"forest"`` and let your pets play in a spooky forest.
 
 .. image:: _static/forest.gif
 
-Set `vscode-pets.theme` to `"castle"` for them to roam the ramparts!
+Set ``vscode-pets.theme`` to ``"castle"`` for them to roam the ramparts!
 
 .. image:: _static/castle.gif
 
-Set `vscode-pets.theme` to `"beach"` for your friends to play by the ocean.
+Set ``vscode-pets.theme`` to ``"beach"`` for your friends to play by the ocean.
 
 .. image:: _static/beach-pose.png

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -92,7 +92,7 @@ Play catch with your pet! Click the ball icon in the VS Code Pets panel to throw
 
 .. image:: _static/throw-ball.gif
 
-You can also use the "Throw ball" command (``vscode-pets.throw-bal`l`).
+You can also use the "Throw ball" command (``vscode-pets.throw-ball``).
 
 * Rocky will not run & catch a ball. Have you ever seen a rock run after a ball? Neither have we.
 


### PR DESCRIPTION
This should change inline code spans from being rendered with `<cite>` to `<code>`. I haven't had a chance to render this myself yet, and I don't have much experience with RST, but I believe *double* backticks (``` `` ```) are inline code spans according to the spec.

I didn't want to introduce any HTML into these nice, HTML-free documents, but rendering keyboard keys with `<kbd>` might be nice. For example, <kbd>Ctrl</kbd>+<kbd>,</kbd>