### PR TITLE
The chasing pet moves at the speed of its friend only if friend is slower

### DIFF
--- a/src/panel/states.ts
+++ b/src/panel/states.ts
@@ -354,14 +354,17 @@ export class ChaseFriendState implements IState {
         if (!this.pet.hasFriend || !this.pet.friend?.isPlaying) {
             return FrameResult.stateCancel; // Friend is no longer playing.
         }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        // Pet uses speed of friend during chase if friend is slower
+        /* eslint-disable @typescript-eslint/no-non-null-assertion */
+        const speed = this.pet.speed > this.pet.friend!.speed ? this.pet.friend!.speed : this.pet.speed;
         if (this.pet.left > this.pet.friend!.left) {
             this.horizontalDirection = HorizontalDirection.left;
-            this.pet.positionLeft(this.pet.left - this.pet.speed);
+            this.pet.positionLeft(this.pet.left - speed);
         } else {
             this.horizontalDirection = HorizontalDirection.right;
-            this.pet.positionLeft(this.pet.left + this.pet.speed);
+            this.pet.positionLeft(this.pet.left + speed);
         }
+        /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
         return FrameResult.stateContinue;
     }

--- a/src/panel/states.ts
+++ b/src/panel/states.ts
@@ -356,7 +356,10 @@ export class ChaseFriendState implements IState {
         }
         // Pet uses speed of friend during chase if friend is slower
         /* eslint-disable @typescript-eslint/no-non-null-assertion */
-        const speed = this.pet.speed > this.pet.friend!.speed ? this.pet.friend!.speed : this.pet.speed;
+        const speed =
+            this.pet.speed > this.pet.friend!.speed
+                ? this.pet.friend!.speed
+                : this.pet.speed;
         if (this.pet.left > this.pet.friend!.left) {
             this.horizontalDirection = HorizontalDirection.left;
             this.pet.positionLeft(this.pet.left - speed);


### PR DESCRIPTION
Fix for #585 
Alternative to #599  

From suggestion 2: The chasing pet moves at the speed of it's friend - https://github.com/sharktrexer/vscode-pets/blob/main/src/panel/states.ts#L357-L367

Pets now use the slower friend's speed. I assumed it made more sense for only faster pets to move slower rather than slower pets moving faster. I can make a change for slower pets to keep with with faster pets if desired.