### PR TITLE
User has the option to spawn or delete a random pet

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
         "onCommand:vscode-pets.throw-with-mouse",
         "onCommand:vscode-pets.throw-ball",
         "onCommand:vscode-pets.spawn-pet",
+        "onCommand:vscode-pets.spawn-rand-pet",
         "onCommand:vscode-pets.delete-pet",
+        "onCommand:vscode-pets.delete-rand-pet",
         "onCommand:vscode-pets.remove-all-pets",
         "onCommand:vscode-pets.roll-call",
         "onCommand:vscode-pets.export-pet-list",
@@ -123,8 +125,26 @@
                 }
             },
             {
+                "command": "vscode-pets.spawn-rand-pet",
+                "title": "Spawn additional random pet",
+                "category": "Pet Coding",
+                "icon": {
+                    "dark": "media/icon/dark-add.svg",
+                    "light": "media/icon/light-add.svg"
+                }
+            },
+            {
                 "command": "vscode-pets.delete-pet",
                 "title": "Remove pet",
+                "category": "Pet Coding",
+                "icon": {
+                    "dark": "media/icon/dark-trash.svg",
+                    "light": "media/icon/light-trash.svg"
+                }
+            },
+            {
+                "command": "vscode-pets.delete-rand-pet",
+                "title": "Remove a random pet",
                 "category": "Pet Coding",
                 "icon": {
                     "dark": "media/icon/dark-trash.svg",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -395,6 +395,34 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand(
+            'vscode-pets.delete-rand-pet',
+            async () => {
+                const panel = getPetPanel();
+                if (panel !== undefined) {
+                    panel.deleteRandomPet();
+                } else {
+                    await createPetPlayground(context);
+                }
+            },
+        ),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'vscode-pets.spawn-rand-pet',
+            async () => {
+                const panel = getPetPanel();
+                if (panel !== undefined) {
+                    panel.spawnRandomPet();
+                } else {
+                    await createPetPlayground(context);
+                }
+            },
+        ),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
             'vscode-pets.export-pet-list',
             async () => {
                 const pets = PetSpecification.collectionFromMemento(
@@ -689,7 +717,9 @@ interface IPetPanel {
     throwBall(): void;
     resetPets(): void;
     spawnPet(spec: PetSpecification): void;
+    spawnRandomPet(): void;
     deletePet(petName: string): void;
+    deleteRandomPet(): void;
     listPets(): void;
     rollCall(): void;
     themeKind(): vscode.ColorThemeKind;
@@ -791,6 +821,12 @@ class PetWebviewContainer implements IPetPanel {
         });
     }
 
+    public deleteRandomPet(): void {
+        void this.getWebview().postMessage({
+            command: 'delete-rand-pet',
+        });
+    }
+
     public spawnPet(spec: PetSpecification) {
         void this.getWebview().postMessage({
             command: 'spawn-pet',
@@ -801,6 +837,12 @@ class PetWebviewContainer implements IPetPanel {
         void this.getWebview().postMessage({
             command: 'set-size',
             size: spec.size,
+        });
+    }
+
+    public spawnRandomPet(): void {
+        void this.getWebview().postMessage({
+            command: 'spawn-rand-pet',
         });
     }
 

--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -591,6 +591,29 @@ export function petPanelApp(
                     });
                 }
                 break;
+            case 'delete-rand-pet':
+                var pet = allPets.locate(
+                    allPets.pets[
+                        Math.floor(Math.random() * allPets.pets.length)
+                    ].pet.name,
+                );
+                if (pet) {
+                    allPets.remove(pet.pet.name);
+                    saveState(stateApi);
+                    stateApi?.postMessage({
+                        command: 'info',
+                        text:
+                            '👋 Randomly selected ' +
+                            pet.pet.name +
+                            ' to be removed',
+                    });
+                } else {
+                    stateApi?.postMessage({
+                        command: 'error',
+                        text: `Could not find pet to delete`,
+                    });
+                }
+                break;
             case 'reset-pet':
                 allPets.reset();
                 petCounter = 0;

--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -7,6 +7,7 @@ import {
     Theme,
     ColorThemeKind,
     WebviewMessage,
+    ALL_PETS,
 } from '../common/types';
 import { IPetType } from './states';
 import {
@@ -552,7 +553,25 @@ export function petPanelApp(
                 );
                 saveState(stateApi);
                 break;
-
+            case 'spawn-rand-pet':
+                const randPetType =
+                    ALL_PETS[Math.floor(Math.random() * ALL_PETS.length)];
+                const randPetColors = availableColors(randPetType);
+                allPets.push(
+                    addPetToPanel(
+                        randPetType,
+                        basePetUri,
+                        randPetColors[
+                            Math.floor(Math.random() * randPetColors.length)
+                        ],
+                        petSize,
+                        randomStartPosition(),
+                        floor,
+                        floor,
+                        randomName(randPetType),
+                        stateApi,
+                    ),
+                );
             case 'list-pets':
                 var pets = allPets.pets;
                 stateApi?.postMessage({


### PR DESCRIPTION
Idea from #138 

Hopefully this isn't too spammy. I have enjoyed this extension a lot and love that I can contribute to it!

I added new commands to the extension so that if someone wants to spice up their pet panel, they can do so using the power of randomness. 

### Spawning a random pet
![spawn random pet](https://github.com/user-attachments/assets/03fc2faf-4fbb-434a-89ea-77a6e03dec50)

### Deleting a random pet
![delete random pet](https://github.com/user-attachments/assets/dd37e593-fb7b-425a-a1e7-92515017b50d)

### Issues
After running this code and the "npm run" command, the cat animations are missing. Is this normal because of the encryption or did I perhaps break it myself?