### PR TITLE
Persist pets across windows/workspaces when using the explorer position

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -290,6 +290,18 @@ export function activate(context: vscode.ExtensionContext) {
                 webviewViewProvider
             ) {
                 await vscode.commands.executeCommand('petsView.focus');
+
+                // Clear out saved pets from the workspace
+                webviewViewProvider.resetPets();
+
+                // Load the pets from the memento
+                var collection = PetSpecification.collectionFromMemento(
+                    context,
+                    getConfiguredSize(),
+                );
+                collection.forEach((item) => {
+                    webviewViewProvider.spawnPet(item);
+                });
             } else {
                 const spec = PetSpecification.fromConfiguration();
                 PetPanel.createOrShow(
@@ -1113,6 +1125,9 @@ class PetWebviewViewProvider extends PetWebviewContainer {
             null,
             this._disposables,
         );
+
+        // Replace the workspace-saved pets with the global ones
+        vscode.commands.executeCommand("vscode-pets.start");
     }
 
     update() {


### PR DESCRIPTION
There seems to be a good amount of interest (#409, #543, #587, #643, #728, #809, and myself!) in having pets saved to a global state when the extension is operating in the explorer position. So, I've taken a stab at that.

I've repurposed the `vscode-pets.start` command slightly, so that it also removes all currently visible pets and loads them from the memento, in the same way that the panel position mode does.
I've also instructed the extension to run the `vscode-pets.start` command when the explorer view is first resolved.

A couple notes:
- The behavior of the panel position mode (which already persists in global state) has not been modified.
- As the implementation currently stands, any pets the user currently has in the workspace state are ignored.