### PR TITLE
Fix/ speech bubble no longer hidden behind background

### DIFF
--- a/media/pets.css
+++ b/media/pets.css
@@ -180,7 +180,7 @@ img.pet {
 	border: 2px solid #333;
 	border-radius: 10px;
 	padding: 10px 0;
-    z-index: var(--bubble-z-index);
+	z-index: var(--bubble-z-index);
 }
 
 .bubble-nano {

--- a/media/pets.css
+++ b/media/pets.css
@@ -1,14 +1,12 @@
-/*
- * z-index values:
- * 1: backgroundEffectCanvas
- * 2: background
- * 3: petCanvasContainer canvas, ballCanvas, img.pet
- * 4: foregroundEffectCanvas
- * 5: foreground
- * 999: collision
- */
-
 :root {
+    --background-effect-canvas-z-index: 1;
+    --background-z-index: 2;
+    --pet-canvas-container-z-index: 3; /* petCanvasContainer canvas, ballCanvas, img.pet */
+    --bubble-z-index: 4;
+    --foreground-effect-canvas-z-index: 5;
+    --foreground-z-index: 6;
+    --collision-z-index: 999;
+
 	--container-paddding: 20px;
 	--input-padding-vertical: 6px;
 	--input-padding-horizontal: 4px;
@@ -37,7 +35,7 @@ body {
 	position: absolute;
 	top: 0;
 	left: 0;
-	z-index: 5;
+	z-index: var(--foreground-z-index);
 	background-attachment: fixed;
 	background-repeat: repeat-x;
 	background-position: bottom left;
@@ -49,7 +47,7 @@ body {
 	position: absolute;
 	top: 0;
 	left: 0;
-	z-index: 2;
+	z-index: var(--background-z-index);
 	background-attachment: fixed;
 	background-repeat: repeat-x;
 	background-position: bottom left;
@@ -140,17 +138,17 @@ textarea::placeholder {
 	position: fixed;
 	bottom: 0;
 	left: 0;
-	z-index: 3;
+	z-index: var(--pet-canvas-container-z-index);
 }
 
 #ballCanvas {
-	z-index: 3;
+	z-index: var(--pet-canvas-container-z-index);
 }
 #foregroundEffectCanvas {
-	z-index: 4 !important;
+	z-index: var(--foreground-effect-canvas-z-index) !important;
 }
 #backgroundEffectCanvas {
-	z-index: 1 !important;
+	z-index: var(--background-effect-canvas-z-index) !important;
 }
 
 img.pet {
@@ -160,7 +158,7 @@ img.pet {
 	left: 0px;
 	right: 0px;
 	bottom:0px;
-	z-index: 3;
+	z-index: var(--pet-canvas-container-z-index);
 }
 
 .collision {
@@ -168,7 +166,7 @@ img.pet {
 	left: 0px;
 	right: 0px;
 	bottom:0px;
-	z-index: 999;
+	z-index: var(--collision-z-index);
 }
 
 .bubble {
@@ -182,6 +180,7 @@ img.pet {
 	border: 2px solid #333;
 	border-radius: 10px;
 	padding: 10px 0;
+    z-index: var(--bubble-z-index);
 }
 
 .bubble-nano {

--- a/media/pets.css
+++ b/media/pets.css
@@ -1,11 +1,11 @@
 :root {
-    --background-effect-canvas-z-index: 1;
-    --background-z-index: 2;
-    --pet-canvas-container-z-index: 3; /* petCanvasContainer canvas, ballCanvas, img.pet */
-    --bubble-z-index: 4;
-    --foreground-effect-canvas-z-index: 5;
-    --foreground-z-index: 6;
-    --collision-z-index: 999;
+	--background-effect-canvas-z-index: 1;
+	--background-z-index: 2;
+	--pet-canvas-container-z-index: 3; /* petCanvasContainer canvas, ballCanvas, img.pet */
+	--bubble-z-index: 4;
+	--foreground-effect-canvas-z-index: 5;
+	--foreground-z-index: 6;
+	--collision-z-index: 999;
 
 	--container-paddding: 20px;
 	--input-padding-vertical: 6px;


### PR DESCRIPTION
Fixes issue **#698**.

The speech bubble will now appear in front of any backgrounds, but still behind foregrounds since the speech bubble belongs to pets, who are located similarly.

### Before:
![417994828-16e2429a-60f3-4a6e-b5e6-1441fac24b4a](https://github.com/user-attachments/assets/64219a25-27f4-4e82-8d93-df62edd8fbab)
![417994827-5187f2be-a129-48a8-8089-db232604a7d4](https://github.com/user-attachments/assets/3f3a7a5e-487a-4072-ba1d-c8b3cc8f4d8d)

### After:
![Screenshot 2025-03-06 103514](https://github.com/user-attachments/assets/eb1395b0-133c-4331-a981-80963cc1efe0)
![Screenshot 2025-03-06 103308](https://github.com/user-attachments/assets/ee8d62c9-6b0e-4825-8b20-697c09d6d5d3)
