### PR TITLE
feat: put bubbles on top of foreground

### DIFF
--- a/media/pets.css
+++ b/media/pets.css
@@ -2,9 +2,9 @@
 	--background-effect-canvas-z-index: 1;
 	--background-z-index: 2;
 	--pet-canvas-container-z-index: 3; /* petCanvasContainer canvas, ballCanvas, img.pet */
-	--bubble-z-index: 4;
-	--foreground-effect-canvas-z-index: 5;
-	--foreground-z-index: 6;
+	--foreground-effect-canvas-z-index: 4;
+	--foreground-z-index: 5;
+	--bubble-z-index: 6;
 	--collision-z-index: 999;
 
 	--container-paddding: 20px;


### PR DESCRIPTION
The bubbles tend to disappear behind foreground objects in some themes (like forest), I think it's more readable with them always on top.