### PR TITLE
Update timer moved to Extension

### DIFF
--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -62,17 +62,6 @@ function startAnimations(
     }
 
     collision.addEventListener('mouseover', handleMouseOver);
-    setInterval(() => {
-        var updates = allPets.seekNewFriends();
-        updates.forEach((message) => {
-            stateApi?.postMessage({
-                text: message,
-                command: 'info',
-            });
-        });
-        pet.nextFrame();
-        saveState(stateApi);
-    }, 100);
 }
 
 function addPetToPanel(
@@ -342,6 +331,21 @@ export function petPanelApp(
         }
     }
 
+    let windowLoaded = false;
+    const onTick = () => {
+        if (windowLoaded) {
+            allPets.seekNewFriends();
+            allPets.pets.forEach((petItem) => {
+                petItem.pet.nextFrame();
+            });
+            saveState(stateApi);
+        }
+    };
+
+    window.addEventListener('load', () => {
+        windowLoaded = true;
+    });
+
     // Handle messages sent from the extension to the webview
     window.addEventListener('message', (event): void => {
         const message = event.data; // The json data that the extension sent
@@ -430,6 +434,9 @@ export function petPanelApp(
                 } else if (themeInfo.effect && !message.disabled) {
                     themeInfo.effect.enable();
                 }
+                break;
+            case 'tick':
+                onTick();
                 break;
         }
     });

--- a/src/panel/pets.ts
+++ b/src/panel/pets.ts
@@ -58,7 +58,7 @@ export interface IPetCollection {
     pets: Array<PetElement>;
     push(pet: PetElement): void;
     reset(): void;
-    seekNewFriends(): string[];
+    seekNewFriends(): void;
     locate(name: string): PetElement | undefined;
     locatePet(
         name: string,
@@ -121,44 +121,41 @@ export class PetCollection implements IPetCollection {
         });
     }
 
-    seekNewFriends(): string[] {
+    seekNewFriends(): void {
         if (this._pets.length <= 1) {
-            return [];
+            return;
         } // You can't be friends with yourself.
-        var messages = new Array<string>(0);
-        this._pets.forEach((petInCollection) => {
-            if (petInCollection.pet.hasFriend) {
-                return;
-            } // I already have a friend!
-            this._pets.forEach((potentialFriend) => {
-                if (potentialFriend.pet.hasFriend) {
-                    return;
-                } // Already has a friend. sorry.
+        const theFriendless = this._pets.filter((pet) => !pet.pet.hasFriend);
+        if (theFriendless.length <= 1) {
+            return;
+        } // Nobody to be friends with.
+        theFriendless.forEach((lonelyPet) => {
+            const potentialFriends = theFriendless.filter(
+                (pet) => pet !== lonelyPet,
+            ); // Exclude the lonely pet itself.
+            potentialFriends.forEach((potentialFriend) => {
                 if (!potentialFriend.pet.canChase) {
                     return;
                 } // Pet is busy doing something else.
                 if (
-                    potentialFriend.pet.left > petInCollection.pet.left &&
+                    potentialFriend.pet.left > lonelyPet.pet.left &&
                     potentialFriend.pet.left <
-                        petInCollection.pet.left + petInCollection.pet.width
+                        lonelyPet.pet.left + lonelyPet.pet.width
                 ) {
                     // We found a possible new friend..
                     console.log(
-                        petInCollection.pet.name,
+                        lonelyPet.pet.name,
                         ' wants to be friends with ',
                         potentialFriend.pet.name,
                         '.',
                     );
-                    if (
-                        petInCollection.pet.makeFriendsWith(potentialFriend.pet)
-                    ) {
+                    if (lonelyPet.pet.makeFriendsWith(potentialFriend.pet)) {
                         potentialFriend.pet.showSpeechBubble('❤️', 2000);
-                        petInCollection.pet.showSpeechBubble('❤️', 2000);
+                        lonelyPet.pet.showSpeechBubble('❤️', 2000);
                     }
                 }
             });
         });
-        return messages;
     }
 }
 

--- a/src/panel/pets/horse.ts
+++ b/src/panel/pets/horse.ts
@@ -126,6 +126,10 @@ export class Horse extends BasePetType {
                 possibleNextStates: [States.idleWithBall],
             },
             {
+                state: States.swipe,
+                possibleNextStates: [States.sitIdle],
+            },
+            {
                 state: States.idleWithBall,
                 // Can go back to running or have a bite to eat
                 possibleNextStates: [


### PR DESCRIPTION
I've noticed that the pets would sometimes be incredibly slow. Reloading VSCode usually fixes it. The issue is also reported here: #731 

I've looked into the issue pretty extensively and believe the the cause is the Chromium Timer Throttling announced here: https://developer.chrome.com/blog/timer-throttling-in-chrome-88/

vscode-pets relies on chained timers (`setInterval` calls started in `startAnimation` for individual pets). When throttled, these timers will execute closer to every 1000 ms at the smallest duration. This effectively makes all pets update at a rate of once per second rather than once every 100ms. This matches the experience of [gyori-andris](https://github.com/gyori-andris) who guessed the pets were running at 1/10th the speed.

I tried to implement the recommendations laid out in the announcement including `requestAnimationFrame`, ensuring the webview was visible, and even the introduction of a web worker. None of these approaches reliably solved the issue and throttling was still sometimes applied - with no way to recover even when the extension was aware it was throttled.

As part of my investigation, I reworked the logic a bit to see if it was merely a performance issue. These changes did NOT address the throttling, but they still seemed valuable so I have left them in, but no worries if that isn't something you want. Specifically:
- Removed individual setIntervals from startAnimations
  - single call for all pets every 100ms that calls `nextFrame` using the `allPets` collection
  - prevents saveState being called by every pet every update
  - prevents friend logic being called by every pet every update
- Simplified seekNewFriends logic
  - Was double looping
  - Removed message responses and handling logic since it was unused

Ultimately, I found that the extension itself is not subject to the throttling and moved the interval trigger there (ticks). This allows the logic to stay in the webview by simply handling the `tick` message.
- No intervals at all in webview, instead updates moved to message response
- Extended the IPetPanel to add dispose and tick
- Moved cleanup to base class
- Eliminated duplicate functions in PetPanel

You can see the issue and the fix in this gif:
![ChromiumTimerThrottling](https://github.com/user-attachments/assets/02da19e0-0aba-4bf7-9335-db518daad9dd)

In the above, the `onTick` method was being triggered using the same `setInterval` logic as before (called from within the webview) and on each call it was doing the `nextFrame` and friend updates and writing `update` to the console. Meanwhile, the `tick` message was being handled with a simple `Tick received` to the console.

Generally, these were firing one after another (since they are both set to 100ms). But, when throttling was applied (approximately 1 in every 5 loads in my testing), you can see that the `update` messages are throttled, the horse is in slow-mo but the `Tick received` messages are still coming in as expected. In fact, you can see there's generally 10 ticks received for every update.

I've tested this update in both Panel and Explorer views and have found it reliably solves the timing issue. However, I have found that if VS Code is loading slowly, vscode-pets can start the animation a little slow for the initial second or so. This isn't every time and it's not very noticeable (in fact, I only saw it twice), but it is a potential disadvantage of this approach. But I think it's far preferrable to the unrecoverable slow-mo that happens with throttling.

Hopefully this helps! Thanks again for the awesome extension!