### PR TITLE
Speech Bubble Readability

### DIFF
--- a/media/pets.css
+++ b/media/pets.css
@@ -173,13 +173,14 @@ img.pet {
 	position: absolute;
 	text-align: center;
 	background-color: #fff;
+	color: #333;
 	font-family: silkscreen, sans-serif;
-	width: 60px;
+	min-width: 60px;
 	line-height: 1.4em;
 	margin: 0px auto;
 	border: 2px solid #333;
 	border-radius: 10px;
-	padding: 10px 0;
+	padding: 10px 4px;
 	z-index: var(--bubble-z-index);
 }
 


### PR DESCRIPTION
As mentioned in #730, the speech bubble can be hard to read. As it me that introduced this problem, thought I'd take a stab at addressing it.

There are actually 2 issues. The first is when non-emoji messages are shown, the default `color` is set to `--vscode-foreground` which would be fine except that the speech bubble is always white regardless of theme. So in a dark theme you get something like this:
![image](https://github.com/user-attachments/assets/2fe296c1-a529-4cd0-860a-071e5ebc0c8c)

The other issue is that the text can sometimes be slightly too large depending on scaling.

To address these, I updated the css for the bubble to define a fixed color for the text and to let it grow a little if the message is wider than expected. This works for standard messages as well as improving readability for the silly horse ones 😄.

<img width="342" alt="image" src="https://github.com/user-attachments/assets/e329566e-622d-4f38-96c1-13049a395e5c" />

<img width="342" alt="image" src="https://github.com/user-attachments/assets/845748d1-7ad2-444f-9423-3d88d08b15a4" />
