### PR TITLE
chore: update @types/node from v18 to v20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-pets",
-    "version": "1.32.0",
+    "version": "1.33.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-pets",
-            "version": "1.32.0",
+            "version": "1.33.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/l10n": "^0.0.10"
@@ -17,7 +17,7 @@
                 "@types/glob": "^7.1.3",
                 "@types/jsdom": "^20.0.0",
                 "@types/mocha": "^9.1.1",
-                "@types/node": "^18.0.0",
+                "@types/node": "^20.19.10",
                 "@types/vscode": "^1.73.0",
                 "@typescript-eslint/eslint-plugin": "^5.29.0",
                 "@typescript-eslint/parser": "^5.29.0",
@@ -1060,10 +1060,14 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.11.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-            "dev": true
+            "version": "20.19.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
+            "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
         },
         "node_modules/@types/semver": {
             "version": "7.3.13",
@@ -7475,6 +7479,13 @@
                 "fastest-levenshtein": "^1.0.7"
             }
         },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/universalify": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -8986,10 +8997,13 @@
             "dev": true
         },
         "@types/node": {
-            "version": "18.11.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-            "dev": true
+            "version": "20.19.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
+            "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~6.21.0"
+            }
         },
         "@types/semver": {
             "version": "7.3.13",
@@ -13788,6 +13802,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-2.0.0.tgz",
             "integrity": "sha512-+hhVICbnp+rlzZMgxXenpvTxpuvA67Bfgtt+O9WOE5jo7w/dyiF1VmoZVIHvP2EkUjsyKyTwYKlLhA+j47m1Ew==",
+            "dev": true
+        },
+        "undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true
         },
         "universalify": {

--- a/package.json
+++ b/package.json
@@ -331,7 +331,7 @@
         "@types/glob": "^7.1.3",
         "@types/jsdom": "^20.0.0",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^18.0.0",
+        "@types/node": "^20.19.10",
         "@types/vscode": "^1.73.0",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0",


### PR DESCRIPTION
update @types/node from v18 to v20