### PR TITLE
Removed codecov file before packaging the VSIX in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
                 directory: ./coverage
                 token: ${{ secrets.CODECOV_TOKEN }}
 
-            - name: Remove coverage files
-              run: rm -rf coverage
+            - name: Remove codecov files
+              run: rm codecov*
 
             - name: Package VSIX
               run: npm install -g @vscode/vsce && vsce package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
               with:
                 directory: ./coverage
                 token: ${{ secrets.CODECOV_TOKEN }}
-            
+
+            - name: Remove coverage files
+              run: rm -rf coverage
+
             - name: Package VSIX
               run: npm install -g @vscode/vsce && vsce package
             - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Removes coverage files before packaging VSIX to prevent a 10MB codecov file from being included in the extension package.

## Changes 
- Added a step in the CI workflow to delete the coverage directory after uploading to codeco,v but before creating the VSIX package

Fixes #792 