### PR TITLE
fix: remove codecov.yml from VSIX package #792

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
                 directory: ./coverage
                 token: ${{ secrets.CODECOV_TOKEN }}
             
-            - name: Remove codecov file before packaging
-              run: rm -f codecov.yml
+            - name: Remove codecov files before packaging
+              run: rm -f codecov*
             - name: Package VSIX
               run: npm install -g @vscode/vsce && vsce package
             - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
                 directory: ./coverage
                 token: ${{ secrets.CODECOV_TOKEN }}
             
+            - name: Remove codecov file before packaging
+              run: rm -f codecov.yml
             - name: Package VSIX
               run: npm install -g @vscode/vsce && vsce package
             - uses: actions/upload-artifact@v4

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,4 +12,4 @@ src/**
 coverage/
 docs/
 node_modules
-codecov.yml
+codecov*

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,4 @@ src/**
 coverage/
 docs/
 node_modules
+codecov.yml


### PR DESCRIPTION
   - Add step to remove codecov.yml before packaging in CI workflow
   - Add codecov.yml to .vscodeignore for additional safety
   - Fixes issue #792 to reduce VSIX package size
   
   fix #792