### PR TITLE
Fixes bug when changing either the pet size or theme doesn't update in panel

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -933,7 +933,9 @@ class PetWebviewContainer implements IPetPanel {
         webview.html = this._getHtmlForWebview(webview);
     }
 
-    public update() {}
+    public update() {
+        this._update();
+    }
 
     protected _getHtmlForWebview(webview: vscode.Webview) {
         // Local path to main script run in the webview


### PR DESCRIPTION
Fixes https://github.com/tonybaloney/vscode-pets/issues/789

The main fix I made was to the update() method in the PetWebViewController class. This was the root cause of why changing the pet size or theme wasn't reloading the window automatically.

Working Demo : 
https://github.com/user-attachments/assets/00e89403-9d81-455a-89d2-f3d542207ba6

