### PR TITLE
Added settling effect to leaves in autumn theme

### DIFF
--- a/src/panel/effects/leaves.ts
+++ b/src/panel/effects/leaves.ts
@@ -33,6 +33,9 @@ class Leaf {
     color: string;
     rotation: number;
     rotationSpeed: number;
+    settled: boolean;
+    settleTime: number;
+    settleDuration: number;
 
     constructor(
         origin: Vector2,
@@ -50,9 +53,17 @@ class Leaf {
         // randomize start values a bit
         this.dx = Math.random() * 100;
         this.rotation = Math.random() * Math.PI * 2; // Random initial rotation
+
+        this.settled = false;
+        this.settleTime = 0;
+        this.settleDuration = floorRandom(2, 5);
     }
 
     update(timeDelta: number) {
+        if (this.settled) {
+            return;
+        }
+
         this.position.y += this.velocity.y * timeDelta;
 
         // oscillate the x value between -amplitude and +amplitude
@@ -195,14 +206,24 @@ export class LeafEffect implements Effect {
             var particle = this.particles[i];
             particle.update(timeDelta);
 
-            if (particle.position.y > this.canvas.height - this.floor) {
-                // reset the particle to the top and a random x position
-                particle.position.y = this.canvas.height - this.treeLine;
-                particle.position.x = particle.origin.x =
-                    Math.random() * this.canvas.width;
-                particle.dx = Math.random() * 100;
-                // Reset rotation to a random value for variety
-                particle.rotation = Math.random() * Math.PI * 2;
+            var leafBottom = particle.position.y + (85 * this.scale);
+
+            if (leafBottom >= this.canvas.height - this.floor) {
+                if (!particle.settled) {
+                    particle.settled = true;
+                    particle.settleTime = timeNow;
+                    particle.position.y = this.canvas.height - this.floor - (85 * this.scale);
+                } else {
+                    if (timeNow - particle.settleTime >= particle.settleDuration) {
+                        particle.position.y = particle.origin.y = this.canvas.height - this.treeLine;
+                        particle.position.x = particle.origin.x =
+                            Math.random() * this.canvas.width;
+                        particle.dx = Math.random() * 100;
+                        particle.rotation = Math.random() * Math.PI * 2;
+                        particle.settled = false;
+                        particle.settleDuration = floorRandom(2, 5);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
  Implements leaf settling behavior for autumn theme (#790)

  Leaves now settle on the ground for 2-5 seconds before respawning from the trees, creating a more realistic autumn effect with gradual leaf accumulation.

  ## Changes
  - Added settling state to `Leaf` class (`settled`, `settleTime`, `settleDuration`)
  - Modified `Leaf.update()` to pause animation when leaf is settled
  - Updated `LeafEffect.update()` to handle settling logic with randomized duration
  - Fixed leaf ground positioning to align with floor level

  ## Test Plan
  - [x] Compile succeeds without errors
  - [ ] Autumn theme shows leaves settling on ground for 2-5 seconds
  - [ ] Leaves respawn from tree line after settling period
  - [ ] No visual glitches with leaf positioning

  Fixes #790