### PR TITLE
feat(ball): allow users to change the ball color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-pets",
-    "version": "1.33.0",
+    "version": "1.34.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-pets",
-            "version": "1.33.0",
+            "version": "1.34.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/l10n": "^0.0.10"

--- a/package.json
+++ b/package.json
@@ -289,12 +289,6 @@
                             "%vscode-pets.position.explorer%"
                         ]
                     },
-                    "vscode-pets.ballColor": {
-                        "type": "string",
-                        "format": "color",
-                        "default": "#2ed851",
-                        "description": "Color of the ball used when playing fetch. Hex color (e.g. #RRGGBB or #RRGGBBAA)."
-                    },
                     "vscode-pets.theme": {
                         "type": "string",
                         "enum": [

--- a/package.json
+++ b/package.json
@@ -289,6 +289,12 @@
                             "%vscode-pets.position.explorer%"
                         ]
                     },
+                    "vscode-pets.ballColor": {
+                        "type": "string",
+                        "format": "color",
+                        "default": "#2ed851",
+                        "description": "Color of the ball used when playing fetch. Hex color (e.g. #RRGGBB or #RRGGBBAA)."
+                    },
                     "vscode-pets.theme": {
                         "type": "string",
                         "enum": [

--- a/package.json
+++ b/package.json
@@ -201,6 +201,12 @@
                             "%vscode-pets.petColor.pink%"
                         ]
                     },
+                    "vscode-pets.ballColor": {
+                        "type": "string",
+                        "format": "color",
+                        "default": "#2ed851",
+                        "description": "Color of the ball used when playing fetch. Hex color (e.g. #RRGGBB or #RRGGBBAA)."
+                    },
                     "vscode-pets.petType": {
                         "type": "string",
                         "enum": [

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -386,7 +386,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand('vscode-pets.throw-ball', () => {
-           const webview = getWebview();
+            const webview = getWebview();
             if (webview) {
                 void webview.postMessage({
                     command: 'set-next-ball-color',
@@ -739,7 +739,10 @@ export function activate(context: vscode.ExtensionContext) {
                     const newColor = getConfiguredBallColor();
                     const webview = getWebview();
                     if (webview) {
-                        void webview.postMessage({ command: 'set-next-ball-color', color: newColor });
+                        void webview.postMessage({
+                            command: 'set-next-ball-color',
+                            color: newColor,
+                        });
                     }
                 }
             },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -25,6 +25,7 @@ const DEFAULT_COLOR = PetColor.brown;
 const DEFAULT_PET_TYPE = PetType.cat;
 const DEFAULT_POSITION = ExtPosition.panel;
 const DEFAULT_THEME = Theme.none;
+const DEFAULT_BALL_COLOR = '#2ed851';
 
 class PetQuickPickItem implements vscode.QuickPickItem {
     constructor(
@@ -48,6 +49,16 @@ class PetQuickPickItem implements vscode.QuickPickItem {
 }
 
 let webviewViewProvider: PetWebviewViewProvider;
+
+function getConfiguredBallColor(): string {
+    const val = vscode.workspace
+        .getConfiguration('vscode-pets')
+        .get<string>('ballColor', DEFAULT_BALL_COLOR);
+    if (!val || typeof val !== 'string') {
+        return DEFAULT_BALL_COLOR;
+    }
+    return val;
+}
 
 function getConfiguredSize(): PetSize {
     var size = vscode.workspace
@@ -375,9 +386,16 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand('vscode-pets.throw-ball', () => {
-            const panel = getPetPanel();
-            if (panel !== undefined) {
-                panel.throwBall();
+           const webview = getWebview();
+            if (webview) {
+                void webview.postMessage({
+                    command: 'set-next-ball-color',
+                    color: getConfiguredBallColor(),
+                });
+                const panel = getPetPanel();
+                if (panel) {
+                    panel.throwBall();
+                }
             }
         }),
     );
@@ -716,6 +734,14 @@ export function activate(context: vscode.ExtensionContext) {
                 if (e.affectsConfiguration('vscode-pets.disableEffects')) {
                     updatePanelDisableEffects();
                 }
+
+                if (e.affectsConfiguration('vscode-pets.ballColor')) {
+                    const newColor = getConfiguredBallColor();
+                    const webview = getWebview();
+                    if (webview) {
+                        void webview.postMessage({ command: 'set-next-ball-color', color: newColor });
+                    }
+                }
             },
         ),
     );
@@ -885,19 +911,11 @@ class PetWebviewContainer implements IPetPanel {
     public async throwBall() {
         const webview = this.getWebview();
 
-        const BALL_COLOR_NAMES = [ 'Red', 'Blue', 'Yellow', 'Green', 'Orange', 'Purple', 'Pink', 'Cyan', 'White', 'Black', ];
-
-        const choice = await vscode.window.showQuickPick(BALL_COLOR_NAMES, {
-            placeHolder: 'Select ball color',
-        });
-
-        if (!choice) {
-            return;
-        }
+        const configuredColor = getConfiguredBallColor();
 
         void webview.postMessage({
             command: 'set-next-ball-color',
-            color: choice.toLowerCase(),
+            color: configuredColor,
         });
 
         void webview.postMessage({ command: 'throw-ball' });
@@ -1029,7 +1047,7 @@ class PetWebviewContainer implements IPetPanel {
 				<div id="foreground"></div>
                 <div id="background"></div>
 				<script nonce="${nonce}" src="${scriptUri}"></script>
-				<script nonce="${nonce}">petApp.petPanelApp("${basePetUri}", "${this.theme()}", ${this.themeKind()}, "${this.petColor()}", "${this.petSize()}", "${this.petType()}", ${this.throwBallWithMouse()}, ${this.disableEffects()});</script>
+				<script nonce="${nonce}">petApp.petPanelApp("${basePetUri}", "${this.theme()}", ${this.themeKind()}, "${this.petColor()}", "${this.petSize()}", "${this.petType()}", ${this.throwBallWithMouse()}, ${this.disableEffects()}, "${getConfiguredBallColor()}");</script>
 			</body>
 			</html>`;
     }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -882,10 +882,25 @@ class PetWebviewContainer implements IPetPanel {
         });
     }
 
-    public throwBall() {
-        void this.getWebview().postMessage({
-            command: 'throw-ball',
+    public async throwBall() {
+        const webview = this.getWebview();
+
+        const BALL_COLOR_NAMES = [ 'Red', 'Blue', 'Yellow', 'Green', 'Orange', 'Purple', 'Pink', 'Cyan', 'White', 'Black', ];
+
+        const choice = await vscode.window.showQuickPick(BALL_COLOR_NAMES, {
+            placeHolder: 'Select ball color',
         });
+
+        if (!choice) {
+            return;
+        }
+
+        void webview.postMessage({
+            command: 'set-next-ball-color',
+            color: choice.toLowerCase(),
+        });
+
+        void webview.postMessage({ command: 'throw-ball' });
     }
 
     public resetPets(): void {

--- a/src/panel/ball.ts
+++ b/src/panel/ball.ts
@@ -177,9 +177,9 @@ function drawBall() {
 }
 
 export function setNextBallColor(color: string) {
-  if (typeof color === 'string' && color.length > 0) {
-    ballColor = color;
-  }
+    if (typeof color === 'string' && color.length > 0) {
+        ballColor = color;
+    }
 }
 
 export function throwAndChase(pets: PetElement[]) {

--- a/src/panel/ball.ts
+++ b/src/panel/ball.ts
@@ -15,7 +15,6 @@ var ballRadius: number;
 var floor: number;
 
 let ballColor: string = '#2ed851'; // default green
-let nextBallColor: string | undefined = undefined;
 
 function calculateBallRadius(size: PetSize): number {
     if (size === PetSize.nano) {
@@ -48,14 +47,6 @@ function resetBall(): void {
     if (canvas) {
         canvas.style.display = 'block';
     }
-
-    if (nextBallColor) {
-        ballColor = nextBallColor;
-        nextBallColor = undefined;
-    } else {
-        ballColor = '#2ed851';
-    }
-
     ballState = new BallState(100, 100, 4, 5);
 }
 
@@ -186,7 +177,9 @@ function drawBall() {
 }
 
 export function setNextBallColor(color: string) {
-    nextBallColor = color;
+  if (typeof color === 'string' && color.length > 0) {
+    ballColor = color;
+  }
 }
 
 export function throwAndChase(pets: PetElement[]) {

--- a/src/panel/ball.ts
+++ b/src/panel/ball.ts
@@ -14,6 +14,9 @@ var canvas: HTMLCanvasElement | null;
 var ballRadius: number;
 var floor: number;
 
+let ballColor: string = '#2ed851'; // default green
+let nextBallColor: string | undefined = undefined;
+
 function calculateBallRadius(size: PetSize): number {
     if (size === PetSize.nano) {
         return 2;
@@ -45,6 +48,14 @@ function resetBall(): void {
     if (canvas) {
         canvas.style.display = 'block';
     }
+
+    if (nextBallColor) {
+        ballColor = nextBallColor;
+        nextBallColor = undefined;
+    } else {
+        ballColor = '#2ed851';
+    }
+
     ballState = new BallState(100, 100, 4, 5);
 }
 
@@ -170,8 +181,12 @@ function drawBall() {
 
     ctx.beginPath();
     ctx.arc(ballState.cx, ballState.cy, ballRadius, 0, 2 * Math.PI, false);
-    ctx.fillStyle = '#2ed851';
+    ctx.fillStyle = ballColor;
     ctx.fill();
+}
+
+export function setNextBallColor(color: string) {
+    nextBallColor = color;
 }
 
 export function throwAndChase(pets: PetElement[]) {

--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -249,8 +249,23 @@ export function petPanelApp(
     petType: PetType,
     throwBallWithMouse: boolean,
     disableEffects: boolean,
+    ballColorOrStateApi?: string | VscodeStateApi,
     stateApi?: VscodeStateApi,
 ) {
+
+    let configuredBallColor: string | undefined;
+
+    if (typeof ballColorOrStateApi === 'string') {
+        configuredBallColor = ballColorOrStateApi;
+        // stateApi may be in the second optional param already
+    } else if (ballColorOrStateApi && typeof (ballColorOrStateApi as VscodeStateApi).postMessage === 'function') {
+        // Caller passed the stateApi in the 9th position
+        stateApi = ballColorOrStateApi as VscodeStateApi;
+        configuredBallColor = undefined;
+    } else {
+        configuredBallColor = undefined;
+    }
+
     if (!stateApi) {
         stateApi = acquireVsCodeApi();
     }
@@ -307,6 +322,10 @@ export function petPanelApp(
 
     initCanvas(PET_CANVAS_ID);
     setupBallThrowing(PET_CANVAS_ID, petSize, floor);
+
+    if (configuredBallColor) {
+        setNextBallColor(configuredBallColor);
+    }
 
     if (throwBallWithMouse) {
         dynamicThrowOn(allPets.pets);

--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -252,13 +252,16 @@ export function petPanelApp(
     ballColorOrStateApi?: string | VscodeStateApi,
     stateApi?: VscodeStateApi,
 ) {
-
     let configuredBallColor: string | undefined;
 
     if (typeof ballColorOrStateApi === 'string') {
         configuredBallColor = ballColorOrStateApi;
         // stateApi may be in the second optional param already
-    } else if (ballColorOrStateApi && typeof (ballColorOrStateApi as VscodeStateApi).postMessage === 'function') {
+    } else if (
+        ballColorOrStateApi &&
+        typeof (ballColorOrStateApi as VscodeStateApi).postMessage ===
+            'function'
+    ) {
         // Caller passed the stateApi in the 9th position
         stateApi = ballColorOrStateApi as VscodeStateApi;
         configuredBallColor = undefined;

--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -24,6 +24,7 @@ import {
     dynamicThrowOn,
     setupBallThrowing,
     throwAndChase,
+    setNextBallColor,
 } from './ball';
 
 const FOREGROUND_EFFECT_CANVAS_ID = 'foregroundEffectCanvas';
@@ -359,6 +360,9 @@ export function petPanelApp(
                 break;
             case 'throw-ball':
                 throwAndChase(allPets.pets);
+                break;
+            case 'set-next-ball-color':
+                setNextBallColor(message.color);
                 break;
             case 'spawn-pet':
                 allPets.push(


### PR DESCRIPTION
## Summary
This PR implements a feature that allows users to select the color of the ball each time they throw it. Fixes #813 
Previously, the ball color was fixed to the default green (#2ed851). With this update, users can personalize their experience by choosing a color once in the settings.

## Changes introduced
- Added a new ballColor setting in the extension settings (vscode-pets.ballColor).
- Users can set their preferred color using a hex code.
- The selected color is applied automatically whenever a ball is thrown.
- Default ball color remains green (#2ed851) if the user hasn’t customized it.

## Future Improvements
- Depending on the background, some colors may still be hard to see. Making all colors fully visible in every theme could be addressed in a future update.