### PR TITLE
Feature: persist pets across workspaces

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -88,9 +88,16 @@ export const enum ColorThemeKind {
     highContrastLight = 4,
 }
 
+export type PetSummary = {
+    name: string;
+    type: PetType;
+    color: PetColor;
+};
+
 export class WebviewMessage {
     text: string;
     command: string;
+    pets?: PetSummary[];
 
     constructor(text: string, command: string) {
         this.text = text;


### PR DESCRIPTION
This PR fixes #809 a bug where spawned (additional) pets disappear when the workspace or folder is changed and only the default pet remains. After this change, pets we spawn in a webview are synchronized to the extension host and persisted in globalState, and are restored when the panel or explorer view is recreated or when switching workspaces.

**Key changes:**
- The webview now tells the extension which pets are currently shown, so the extension saves the real, up-to-date pet list automatically.
- The extension restores that saved pet list whenever a pet panel or the explorer view is opened, so your spawned pets reappear without re-importing.
- Restores are defensive and avoid creating obvious duplicates, and the default pet is only spawned when there really are no saved pets.

**Future improvements:**
- Current implementation mostly “follows you” between folders: if you move to another workspace that already had pets saved, the two lists can merge (your pets move into the new workspace). This is perfectly fine but it depends on user preferences.
- This feature also can be implemented as Global Pets setting. Let users choose whether pets should be saved per workspace or globally across all VS Code instances. Some users might prefer each workspace to keep its own pets.