### PR TITLE
chore: Update deprecated tsc.autoDetect setting to js/ts namespace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,6 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off",
+    "js/ts.tsc.autoDetect": "off",
     "nuxt.isNuxtApp": false
 }


### PR DESCRIPTION
## Description
Replace the deprecated `typescript.tsc.autoDetect` setting with the new `js/ts.tsc.autoDetect` setting.

## Context
The `typescript.tsc.autoDetect` setting was deprecated in VS Code 1.124. The namespace was changed to `js/ts.tsc.autoDetect` to reflect support for both JavaScript and TypeScript files.

## Changes
- Updated `.vscode/settings.json`: `typescript.tsc.autoDetect` → `js/ts.tsc.autoDetect`

## References
- [VS Code 1.124 Release Notes](https://code.visualstudio.com/updates/v1_124)
- [vscode-extension-samples PR #1287](https://github.com/microsoft/vscode-extension-samples/pull/1287)